### PR TITLE
Validate supernode advertised public key length to avoid ed25519 panic

### DIFF
--- a/internal/mesh/supernode_signing.go
+++ b/internal/mesh/supernode_signing.go
@@ -1,6 +1,7 @@
 package mesh
 
 import (
+	"crypto/ed25519"
 	"encoding/hex"
 	"strconv"
 
@@ -37,6 +38,9 @@ func verifySupernodeEnvelope(env gossip.Envelope) bool {
 	}
 	publicKey, err := hex.DecodeString(env.AdvertisedPeerID)
 	if err != nil {
+		return false
+	}
+	if len(publicKey) != ed25519.PublicKeySize {
 		return false
 	}
 	return mcrypto.Verify(publicKey, supernodeSignaturePayload(env), env.AdvertisedSignature)

--- a/internal/mesh/supernode_signing_test.go
+++ b/internal/mesh/supernode_signing_test.go
@@ -68,3 +68,25 @@ func TestHandleSupernodeStatusRejectsInvalidSignature(t *testing.T) {
 		t.Fatalf("expected invalid supernode announce to penalize sender, base=%f new=%f", base, score)
 	}
 }
+
+func TestVerifySupernodeEnvelopeRejectsMalformedPeerIDLength(t *testing.T) {
+	env := gossip.Envelope{
+		Type:                   gossip.TypeSupernodeAnnounce,
+		AdvertisedPeerID:       "00",
+		AdvertisedAddr:         "192.168.1.50:41030",
+		AdvertisedNATType:      string(nat.TypePublic),
+		AdvertisedReachable:    true,
+		AdvertisedRelayCapable: true,
+		AdvertisedSignature:    []byte{1},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("verifySupernodeEnvelope panicked for malformed peer ID length: %v", r)
+		}
+	}()
+
+	if verifySupernodeEnvelope(env) {
+		t.Fatal("expected malformed peer ID length to fail verification")
+	}
+}


### PR DESCRIPTION
### Motivation
- `verifySupernodeEnvelope` decoded attacker-controlled `AdvertisedPeerID` and forwarded it to signature verification without ensuring the decoded key length, allowing `ed25519.Verify` to panic for non-32-byte keys and enabling a remote DoS. 

### Description
- Import `crypto/ed25519` and add an explicit decoded-key length guard in `verifySupernodeEnvelope` that returns false unless `len(publicKey) == ed25519.PublicKeySize`.
- Preserve existing verification flow by calling `mcrypto.Verify` only when the decoded key has the correct length.
- Add a regression test `TestVerifySupernodeEnvelopeRejectsMalformedPeerIDLength` that uses `AdvertisedPeerID: "00"` and asserts verification fails without panicking.

### Testing
- Ran `go test ./internal/mesh -count=1`, which completed successfully (`ok   moss/internal/mesh`).
- The new regression test executed as part of that run and passed, confirming malformed peer IDs are rejected and do not cause panics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebdebe0214832a8eceb9325332a76a)