### PR TITLE
fix: bound pending UDP server handshakes

### DIFF
--- a/internal/transport/udp.go
+++ b/internal/transport/udp.go
@@ -22,6 +22,9 @@ const (
 	udpMessageData          byte = 4
 	udpMessageObserveReq    byte = 5
 	udpMessageObserveResp   byte = 6
+
+	udpPendingServerHandshakeMax = 1024
+	udpPendingServerHandshakeTTL = 10 * time.Second
 )
 
 var errUDPAlreadyConnected = errors.New("udp peer is already connected")
@@ -49,8 +52,9 @@ type udpClientHandshake struct {
 }
 
 type udpServerHandshake struct {
-	hs   *noise.HandshakeState
-	mode byte
+	hs        *noise.HandshakeState
+	mode      byte
+	createdAt time.Time
 }
 
 type udpDialResult struct {
@@ -335,7 +339,12 @@ func (l *UDPListener) handleHandshakeInit(remote *net.UDPAddr, payload []byte) {
 	}
 	key := remote.String()
 	l.mu.Lock()
+	l.pruneExpiredServerHandshakesLocked(time.Now())
 	if l.sessions[key] != nil {
+		l.mu.Unlock()
+		return
+	}
+	if _, exists := l.servers[key]; !exists && len(l.servers) >= udpPendingServerHandshakeMax {
 		l.mu.Unlock()
 		return
 	}
@@ -356,7 +365,10 @@ func (l *UDPListener) handleHandshakeInit(remote *net.UDPAddr, payload []byte) {
 			return
 		}
 		l.mu.Lock()
-		l.servers[key] = &udpServerHandshake{hs: hs, mode: mode}
+		l.pruneExpiredServerHandshakesLocked(time.Now())
+		if l.sessions[key] == nil && (l.servers[key] != nil || len(l.servers) < udpPendingServerHandshakeMax) {
+			l.servers[key] = &udpServerHandshake{hs: hs, mode: mode, createdAt: time.Now()}
+		}
 		l.mu.Unlock()
 		_ = l.writeDatagram(remote, udpMessageHandshakeResp, payload2)
 	case HandshakeModeIK:
@@ -388,6 +400,14 @@ func (l *UDPListener) handleHandshakeInit(remote *net.UDPAddr, payload []byte) {
 		}
 	default:
 		return
+	}
+}
+
+func (l *UDPListener) pruneExpiredServerHandshakesLocked(now time.Time) {
+	for key, pending := range l.servers {
+		if now.Sub(pending.createdAt) > udpPendingServerHandshakeTTL {
+			delete(l.servers, key)
+		}
 	}
 }
 

--- a/internal/transport/udp_test.go
+++ b/internal/transport/udp_test.go
@@ -263,3 +263,49 @@ func TestUDPObserveSTUNContextReportsObservedEndpoint(t *testing.T) {
 		t.Fatalf("expected observed port %d, got %s", clientPort, port)
 	}
 }
+
+func TestUDPHandshakeInitCapsPendingServers(t *testing.T) {
+	identity, err := mcrypto.NewIdentity()
+	if err != nil {
+		t.Fatalf("identity failed: %v", err)
+	}
+	listener, _, err := ListenUDP(0, HandshakeConfig{
+		MeshID:   "mesh-udp-pending-cap",
+		Identity: identity,
+	})
+	if err != nil {
+		t.Fatalf("ListenUDP failed: %v", err)
+	}
+	defer listener.Close()
+
+	initIdentity, err := mcrypto.NewIdentity()
+	if err != nil {
+		t.Fatalf("initiator identity failed: %v", err)
+	}
+	initHS, err := newHandshakeState(HandshakeConfig{
+		MeshID:   "mesh-udp-pending-cap",
+		Identity: initIdentity,
+	}, true, HandshakeModeXX)
+	if err != nil {
+		t.Fatalf("newHandshakeState failed: %v", err)
+	}
+	msg, _, _, err := initHS.WriteMessage(nil, nil)
+	if err != nil {
+		t.Fatalf("WriteMessage failed: %v", err)
+	}
+	msg = append([]byte{HandshakeModeXX}, msg...)
+
+	for i := 0; i < udpPendingServerHandshakeMax+100; i++ {
+		listener.handleHandshakeInit(&net.UDPAddr{
+			IP:   net.IPv4(198, 51, 100, byte((i%254)+1)),
+			Port: 10000 + i,
+		}, msg)
+	}
+
+	listener.mu.Lock()
+	pending := len(listener.servers)
+	listener.mu.Unlock()
+	if pending != udpPendingServerHandshakeMax {
+		t.Fatalf("expected pending handshake cap %d, got %d", udpPendingServerHandshakeMax, pending)
+	}
+}


### PR DESCRIPTION
### Motivation
- The UDP listener stored server-side Noise handshake state in an unbounded `servers` map for every incoming handshake-init, allowing an attacker to flood spoofed init packets and cause unbounded memory growth (remote memory-exhaustion DoS). 
- The change introduces lightweight limits and cleanup to prevent unbounded accumulation while preserving the existing handshake flow.

### Description
- Add configuration constants `udpPendingServerHandshakeMax = 1024` and `udpPendingServerHandshakeTTL = 10 * time.Second` to cap and expire pending server handshakes. 
- Track creation time by extending `udpServerHandshake` with a `createdAt time.Time` field and prune expired entries with a new `pruneExpiredServerHandshakesLocked` helper. 
- Prune stale entries and reject new pending entries when the `servers` map is at capacity inside `handleHandshakeInit`, and only insert a new pending entry when under capacity or replacing an existing key. 
- Add unit test `TestUDPHandshakeInitCapsPendingServers` asserting that repeated distinct handshake-init packets do not grow `servers` beyond `udpPendingServerHandshakeMax`.

### Testing
- Ran `go test ./internal/transport` and the package tests completed successfully (`ok  	moss/internal/transport`).
- Added and ran `TestUDPHandshakeInitCapsPendingServers`, which passed and verifies the pending-handshake cap behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebdff9a894832ab05ef5fb1596c42b)