### PR TITLE
fix(mesh): bound and validate announced known peers

### DIFF
--- a/internal/mesh/direct_connect_test.go
+++ b/internal/mesh/direct_connect_test.go
@@ -98,3 +98,64 @@ func TestHandleKnownPeerEnvelopeDoesNotOverwritePublicAddrWithPrivateAnnounce(t 
 		t.Fatalf("expected public known peer addr to be preserved, got %q", got)
 	}
 }
+
+func TestHandleKnownPeerEnvelopeRejectsInvalidAdvertisedAddr(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Trackers = nil
+	node, err := NewNode("mesh-known-peer-invalid-addr", nil, cfg)
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+
+	node.handleKnownPeerEnvelope(&peerConn{id: "sender-1"}, gossip.Envelope{
+		AdvertisedPeerID: "peer-1",
+		AdvertisedAddr:   "invalid-addr",
+	}, gossip.TypePeerAnnounce)
+
+	node.mu.RLock()
+	defer node.mu.RUnlock()
+	if _, ok := node.knownPeers["peer-1"]; ok {
+		t.Fatal("expected invalid advertised addr to be ignored")
+	}
+}
+
+func TestHandleKnownPeerEnvelopeEvictsOldestKnownPeerAtCapacity(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Trackers = nil
+	node, err := NewNode("mesh-known-peer-capacity", nil, cfg)
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+
+	oldest := "peer-oldest"
+	node.mu.Lock()
+	for i := 0; i < maxKnownPeers; i++ {
+		id := oldest
+		if i > 0 {
+			id = "peer-" + string(rune('a'+(i%26))) + "-" + string(rune('a'+((i/26)%26))) + "-" + string(rune('a'+((i/676)%26))) + "-" + string(rune('a'+((i/17576)%26)))
+		}
+		node.knownPeers[id] = knownPeer{
+			id:       id,
+			addr:     "10.0.0.1:41030",
+			lastSeen: time.Now().Add(-time.Duration(maxKnownPeers-i) * time.Second),
+		}
+	}
+	node.mu.Unlock()
+
+	node.handleKnownPeerEnvelope(&peerConn{id: "sender-1"}, gossip.Envelope{
+		AdvertisedPeerID: "peer-new",
+		AdvertisedAddr:   "10.0.0.2:41030",
+	}, gossip.TypePeerAnnounce)
+
+	node.mu.RLock()
+	defer node.mu.RUnlock()
+	if len(node.knownPeers) != maxKnownPeers {
+		t.Fatalf("expected known peer count to stay capped at %d, got %d", maxKnownPeers, len(node.knownPeers))
+	}
+	if _, ok := node.knownPeers["peer-new"]; !ok {
+		t.Fatal("expected new peer to be inserted after eviction")
+	}
+	if _, ok := node.knownPeers[oldest]; ok {
+		t.Fatal("expected oldest peer to be evicted")
+	}
+}

--- a/internal/mesh/node.go
+++ b/internal/mesh/node.go
@@ -154,6 +154,13 @@ type meshInfo struct {
 	SupernodeReady bool     `json:"supernode_ready"`
 }
 
+const (
+	maxKnownPeers           = 1024
+	maxKnownPeerSnapshot    = 256
+	maxAdvertisedPeerIDLen  = 128
+	maxAdvertisedAddressLen = 256
+)
+
 func NewNode(meshID string, psk []byte, cfg Config) (*Node, error) {
 	return NewNodeWithIdentity(meshID, psk, cfg, nil)
 }
@@ -1063,11 +1070,16 @@ func (n *Node) sendKnownPeerSnapshot(peer *peerConn) {
 		known = append(known, info)
 	}
 	n.mu.RUnlock()
+	sent := 0
 	for _, info := range known {
 		if info.id == peer.id || info.addr == "" {
 			continue
 		}
+		if sent >= maxKnownPeerSnapshot {
+			break
+		}
 		n.sendEnvelope(peer, n.peerAnnouncementEnvelope(info))
+		sent++
 	}
 	n.announceLocalSubscriptionsToPeer(peer)
 }
@@ -1151,6 +1163,18 @@ func (n *Node) handleKnownPeerEnvelope(peer *peerConn, env gossip.Envelope, forw
 	if env.AdvertisedPeerID == "" || env.AdvertisedAddr == "" || env.AdvertisedPeerID == n.localPeerID() {
 		return
 	}
+	if len(env.AdvertisedPeerID) > maxAdvertisedPeerIDLen || len(env.AdvertisedAddr) > maxAdvertisedAddressLen {
+		if peer != nil {
+			n.scoring.PenalizeInvalid(peer.id)
+		}
+		return
+	}
+	if !isValidAdvertisedAddr(env.AdvertisedAddr) {
+		if peer != nil {
+			n.scoring.PenalizeInvalid(peer.id)
+		}
+		return
+	}
 	changed := false
 	n.mu.Lock()
 	current, ok := n.knownPeers[env.AdvertisedPeerID]
@@ -1160,6 +1184,10 @@ func (n *Node) handleKnownPeerEnvelope(peer *peerConn, env gossip.Envelope, forw
 	}
 	lan := current.lan && knownPeerAddrRank(addr) <= 1
 	if !ok || current.addr != addr || !current.direct || current.natType != nat.Type(env.AdvertisedNATType) || current.publicReachable != env.AdvertisedReachable || current.relayCapable != env.AdvertisedRelayCapable {
+		if !ok && len(n.knownPeers) >= maxKnownPeers && !n.evictKnownPeerLocked() {
+			n.mu.Unlock()
+			return
+		}
 		direct := false
 		if ok && current.direct {
 			direct = true
@@ -3180,9 +3208,15 @@ func (n *Node) updateKnownPeer(peerID, addr string, direct bool) {
 	if peerID == "" || addr == "" || peerID == n.localPeerID() {
 		return
 	}
+	if len(peerID) > maxAdvertisedPeerIDLen || len(addr) > maxAdvertisedAddressLen || !isValidAdvertisedAddr(addr) {
+		return
+	}
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	current, ok := n.knownPeers[peerID]
+	if !ok && len(n.knownPeers) >= maxKnownPeers && !n.evictKnownPeerLocked() {
+		return
+	}
 	if ok && current.direct {
 		direct = true
 	}
@@ -3235,6 +3269,49 @@ func (n *Node) connectPeerUDPWithHint(ctx context.Context, targetPeerID, addr st
 	}
 	n.registerPeer(session, true)
 	return nil
+}
+
+func isValidAdvertisedAddr(addr string) bool {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil || host == "" || port == "" {
+		return false
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil || portNum < 1 || portNum > 65535 {
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip != nil {
+		return true
+	}
+	for _, r := range host {
+		if r <= 31 || r == 127 {
+			return false
+		}
+	}
+	return true
+}
+
+func (n *Node) evictKnownPeerLocked() bool {
+	var (
+		staleID   string
+		staleTime time.Time
+	)
+	for peerID, info := range n.knownPeers {
+		if info.direct || peerID == n.localPeerID() {
+			continue
+		}
+		if staleID == "" || info.lastSeen.Before(staleTime) {
+			staleID = peerID
+			staleTime = info.lastSeen
+		}
+	}
+	if staleID == "" {
+		return false
+	}
+	delete(n.knownPeers, staleID)
+	delete(n.peerDials, staleID)
+	return true
 }
 
 func (n *Node) connectBootstrapPeer(ctx context.Context, addr string) error {


### PR DESCRIPTION
### Motivation
- The `peer_announce` flow accepted arbitrary `AdvertisedPeerID`/`AdvertisedAddr` values into the `knownPeers` map with no validation, cap, or eviction, enabling remote peers to cause unbounded memory growth and influence outbound dials.

### Description
- Add fixed safety limits: `maxKnownPeers`, `maxKnownPeerSnapshot`, `maxAdvertisedPeerIDLen`, and `maxAdvertisedAddressLen` and use them to bound storage and snapshot fan-out. 
- Validate announced addresses with `isValidAdvertisedAddr` (checks `host:port`, port range, and rejects control/invalid host bytes) and drop/penalize invalid envelopes in `handleKnownPeerEnvelope` and `updateKnownPeer`.
- When `knownPeers` is full, evict the stalest non-direct entry via `evictKnownPeerLocked()` before inserting, and refuse insertion if no evictable entry exists. 
- Limit replay in `sendKnownPeerSnapshot` to `maxKnownPeerSnapshot` entries and add unit tests exercising invalid address rejection and capacity eviction. 

### Testing
- Ran targeted tests: `go test ./internal/mesh -run 'TestHandleKnownPeerEnvelope(DoesNotOverwritePublicAddrWithPrivateAnnounce|RejectsInvalidAdvertisedAddr|EvictsOldestKnownPeerAtCapacity)$'` which passed. 
- Ran full package tests: `go test ./internal/mesh` which succeeded (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebe0bac888832a86d10c5f11b97202)