### PR TITLE
fix(gossip): prevent unbounded meshPeers growth from untrusted PRUNE input

### DIFF
--- a/internal/gossip/pubsub.go
+++ b/internal/gossip/pubsub.go
@@ -59,8 +59,14 @@ func (m *Manager) SetPeerSubscription(peerID, channel string, subscribed bool) {
 		subscriptions[channel] = struct{}{}
 	} else {
 		delete(subscriptions, channel)
+		if len(subscriptions) == 0 {
+			delete(m.peerSubscriptions, peerID)
+		}
 		if peers, ok := m.meshPeers[channel]; ok {
 			delete(peers, peerID)
+			if len(peers) == 0 {
+				delete(m.meshPeers, channel)
+			}
 		}
 	}
 }
@@ -69,8 +75,11 @@ func (m *Manager) RemovePeer(peerID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.peerSubscriptions, peerID)
-	for _, peers := range m.meshPeers {
+	for channel, peers := range m.meshPeers {
 		delete(peers, peerID)
+		if len(peers) == 0 {
+			delete(m.meshPeers, channel)
+		}
 	}
 }
 
@@ -90,6 +99,9 @@ func (m *Manager) SetMeshPeer(channel, peerID string, inMesh bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	peers, ok := m.meshPeers[channel]
+	if !ok && !inMesh {
+		return
+	}
 	if !ok {
 		peers = make(map[string]struct{})
 		m.meshPeers[channel] = peers
@@ -98,6 +110,9 @@ func (m *Manager) SetMeshPeer(channel, peerID string, inMesh bool) {
 		peers[peerID] = struct{}{}
 	} else {
 		delete(peers, peerID)
+		if len(peers) == 0 {
+			delete(m.meshPeers, channel)
+		}
 	}
 }
 

--- a/internal/gossip/pubsub_test.go
+++ b/internal/gossip/pubsub_test.go
@@ -24,3 +24,25 @@ func TestManagerTracksMeshPeersSeparatelyFromSubscriptions(t *testing.T) {
 		t.Fatal("peer-1 should have been removed from mesh")
 	}
 }
+
+func TestSetMeshPeerDoesNotCreateChannelOnRemove(t *testing.T) {
+	manager := NewManager()
+
+	manager.SetMeshPeer("unknown", "peer-1", false)
+
+	if peers := manager.MeshPeers("unknown"); len(peers) != 0 {
+		t.Fatalf("unexpected mesh peers for unknown channel: %#v", peers)
+	}
+}
+
+func TestRemovePeerCleansEmptyMeshChannels(t *testing.T) {
+	manager := NewManager()
+	manager.SetPeerSubscription("peer-1", "alpha", true)
+	manager.SetMeshPeer("alpha", "peer-1", true)
+
+	manager.RemovePeer("peer-1")
+
+	if peers := manager.MeshPeers("alpha"); len(peers) != 0 {
+		t.Fatalf("expected empty mesh peers after remove, got %#v", peers)
+	}
+}


### PR DESCRIPTION
### Motivation
- Remote PRUNE messages were calling `SetMeshPeer(channel, peerID, false)` with untrusted channel names, and `SetMeshPeer` allocated `meshPeers[channel]` even when removing a peer, allowing an attacker to create many persistent channel entries and exhaust memory.
- `RemovePeer` did not remove empty per-channel maps, so PRUNE-created entries could persist after the peer disconnected.

### Description
- Prevent `SetMeshPeer(..., inMesh=false)` from creating new channel entries by returning early when the channel is not present and `inMesh` is `false` (no allocation on remove). 
- Delete empty channel maps after removing a peer from a channel in `SetMeshPeer`, `SetPeerSubscription`, and `RemovePeer` to ensure `meshPeers` is pruned when entries become empty. 
- Clean up empty per-peer subscription maps in `SetPeerSubscription` when a peer unsubscribes from its last channel. 
- Add unit tests `TestSetMeshPeerDoesNotCreateChannelOnRemove` and `TestRemovePeerCleansEmptyMeshChannels` to cover the regression and ensure empty maps are not retained.

### Testing
- Ran `go test ./internal/gossip` and the package tests passed (`ok`).
- Ran `go test ./...` and the full test suite ran successfully (`ok` for all packages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebdf7efc78832ab42d776409640873)