### PR TITLE
fix: bound gossip replay cache and suppression memory

### DIFF
--- a/internal/gossip/cache.go
+++ b/internal/gossip/cache.go
@@ -14,15 +14,17 @@ type CacheEntry struct {
 }
 
 type Cache struct {
-	mu    sync.Mutex
-	ttl   time.Duration
-	items map[string]CacheEntry
+	mu         sync.Mutex
+	ttl        time.Duration
+	maxEntries int
+	items      map[string]CacheEntry
 }
 
 func NewCache(ttl time.Duration) *Cache {
 	return &Cache{
-		ttl:   ttl,
-		items: make(map[string]CacheEntry),
+		ttl:        ttl,
+		maxEntries: 2048,
+		items:      make(map[string]CacheEntry),
 	}
 }
 
@@ -37,33 +39,41 @@ func (c *Cache) Seen(id string) bool {
 func (c *Cache) Add(id string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.items[id] = CacheEntry{SeenAt: time.Now()}
+	now := time.Now()
+	c.purgeLocked(now)
+	c.items[id] = CacheEntry{SeenAt: now}
+	c.enforceMaxEntriesLocked()
 }
 
 func (c *Cache) Store(env Envelope) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	now := time.Now()
+	c.purgeLocked(now)
 	c.items[env.MessageID] = CacheEntry{
-		SeenAt:     time.Now(),
+		SeenAt:     now,
 		Channel:    env.Channel,
 		Envelope:   env,
 		HasPayload: true,
 	}
+	c.enforceMaxEntriesLocked()
 }
 
 func (c *Cache) StoreIfNew(env Envelope) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.purgeLocked(time.Now())
+	now := time.Now()
+	c.purgeLocked(now)
 	if _, ok := c.items[env.MessageID]; ok {
 		return false
 	}
 	c.items[env.MessageID] = CacheEntry{
-		SeenAt:     time.Now(),
+		SeenAt:     now,
 		Channel:    env.Channel,
 		Envelope:   env,
 		HasPayload: true,
 	}
+	c.enforceMaxEntriesLocked()
 	return true
 }
 
@@ -110,5 +120,22 @@ func (c *Cache) purgeLocked(now time.Time) {
 		if now.Sub(entry.SeenAt) > c.ttl {
 			delete(c.items, key)
 		}
+	}
+}
+
+func (c *Cache) enforceMaxEntriesLocked() {
+	for len(c.items) > c.maxEntries {
+		oldestID := ""
+		oldestTime := time.Now()
+		for id, entry := range c.items {
+			if oldestID == "" || entry.SeenAt.Before(oldestTime) {
+				oldestID = id
+				oldestTime = entry.SeenAt
+			}
+		}
+		if oldestID == "" {
+			return
+		}
+		delete(c.items, oldestID)
 	}
 }

--- a/internal/gossip/cache_test.go
+++ b/internal/gossip/cache_test.go
@@ -61,3 +61,23 @@ func TestCacheStoreIfNewRejectsDuplicateMessageID(t *testing.T) {
 		t.Fatalf("expected original payload to be preserved, got %q", string(env.Payload))
 	}
 }
+
+func TestCacheEvictsOldestWhenMaxEntriesReached(t *testing.T) {
+	cache := NewCache(time.Minute)
+	cache.maxEntries = 2
+	cache.Store(Envelope{Type: TypePublish, Channel: "alpha", MessageID: "m1", Payload: []byte("one")})
+	time.Sleep(time.Millisecond)
+	cache.Store(Envelope{Type: TypePublish, Channel: "alpha", MessageID: "m2", Payload: []byte("two")})
+	time.Sleep(time.Millisecond)
+	cache.Store(Envelope{Type: TypePublish, Channel: "alpha", MessageID: "m3", Payload: []byte("three")})
+
+	if _, ok := cache.Get("m1"); ok {
+		t.Fatal("expected oldest cached envelope to be evicted")
+	}
+	if _, ok := cache.Get("m2"); !ok {
+		t.Fatal("expected newer cached envelope to be retained")
+	}
+	if _, ok := cache.Get("m3"); !ok {
+		t.Fatal("expected newest cached envelope to be retained")
+	}
+}

--- a/internal/mesh/gossip_mesh_test.go
+++ b/internal/mesh/gossip_mesh_test.go
@@ -1,6 +1,7 @@
 package mesh
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -147,5 +148,52 @@ func TestMeshDeliveryDeficitSkipsPeersThatForward(t *testing.T) {
 	}
 	if score := node.scoring.Score("peer-b"); score != 0 {
 		t.Fatalf("expected peer-b to avoid deficit penalty, got %f", score)
+	}
+}
+
+func TestInboundPublishAboveMaxSizeIsRejected(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Security.MaxMessageSizeBytes = 8
+	node, err := NewNode("mesh-publish-size-limit", nil, cfg)
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+	node.pubsub.Subscribe("alpha")
+	peerID := "peer-oversize"
+	payload := []byte("payload-too-large")
+
+	node.handleEnvelope(&peerConn{id: peerID}, gossip.Envelope{
+		Type:      gossip.TypePublish,
+		Channel:   "alpha",
+		MessageID: "msg-oversized",
+		Payload:   payload,
+	})
+
+	if _, ok := node.cache.Get("msg-oversized"); ok {
+		t.Fatal("expected oversized publish to be rejected before caching")
+	}
+	if score := node.scoring.Score(peerID); score >= 0 {
+		t.Fatalf("expected invalid publish to penalize peer, got %f", score)
+	}
+}
+
+func TestRememberSuppressionCapsPerPeerEntries(t *testing.T) {
+	node, err := NewNode("mesh-suppression-cap", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+	peerID := "peer-suppress"
+	ids := make([]string, maxSuppressionEntriesPerPeer+32)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("msg-%d", i)
+	}
+
+	node.rememberSuppression(peerID, ids, "")
+
+	node.mu.RLock()
+	defer node.mu.RUnlock()
+	entry := node.suppress[peerID]
+	if len(entry) > maxSuppressionEntriesPerPeer {
+		t.Fatalf("expected suppression entries to be capped at %d, got %d", maxSuppressionEntriesPerPeer, len(entry))
 	}
 }

--- a/internal/mesh/node.go
+++ b/internal/mesh/node.go
@@ -78,6 +78,12 @@ type Node struct {
 	dispatchCh       chan any
 }
 
+const (
+	maxSuppressionEntriesPerPeer = 1024
+	maxSuppressionIDsPerMessage  = 256
+	suppressionTTL               = 2 * time.Minute
+)
+
 type peerConn struct {
 	id          string
 	addr        string
@@ -976,6 +982,10 @@ func (n *Node) handleEnvelope(peer *peerConn, env gossip.Envelope) {
 			return
 		}
 		if env.Channel == "" || env.MessageID == "" {
+			n.scoring.PenalizeInvalid(peer.id)
+			return
+		}
+		if len(env.Payload) > n.config.Security.MaxMessageSizeBytes {
 			n.scoring.PenalizeInvalid(peer.id)
 			return
 		}
@@ -1970,6 +1980,9 @@ func (n *Node) rememberSuppression(peerID string, ids []string, fallback string)
 	if len(ids) == 0 && fallback != "" {
 		ids = []string{fallback}
 	}
+	if len(ids) > maxSuppressionIDsPerMessage {
+		ids = ids[:maxSuppressionIDsPerMessage]
+	}
 	if len(ids) == 0 {
 		return
 	}
@@ -1981,7 +1994,14 @@ func (n *Node) rememberSuppression(peerID string, ids []string, fallback string)
 		n.suppress[peerID] = entry
 	}
 	now := time.Now()
+	pruneSuppressionLocked(entry, now)
 	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		for len(entry) >= maxSuppressionEntriesPerPeer {
+			evictOldestSuppressionLocked(entry)
+		}
 		entry[id] = now
 	}
 }
@@ -1997,11 +2017,33 @@ func (n *Node) isSuppressed(peerID, messageID string) bool {
 	if !ok {
 		return false
 	}
-	if time.Since(ts) > 2*time.Minute {
+	if time.Since(ts) > suppressionTTL {
 		delete(entry, messageID)
 		return false
 	}
 	return true
+}
+
+func pruneSuppressionLocked(entry map[string]time.Time, now time.Time) {
+	for id, ts := range entry {
+		if now.Sub(ts) > suppressionTTL {
+			delete(entry, id)
+		}
+	}
+}
+
+func evictOldestSuppressionLocked(entry map[string]time.Time) {
+	oldestID := ""
+	oldestAt := time.Now()
+	for id, ts := range entry {
+		if oldestID == "" || ts.Before(oldestAt) {
+			oldestID = id
+			oldestAt = ts
+		}
+	}
+	if oldestID != "" {
+		delete(entry, oldestID)
+	}
 }
 
 func (n *Node) maintainTopicMesh(channel string) {


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth in gossip replay and suppression paths that allows remote peers to cause OOM by sending many or large `TypePublish`/`TypeIDontWant` messages.

### Description
- Add a `maxEntries` cap (default `2048`) and oldest-first eviction to the gossip `Cache` and enforce it on `Add`, `Store`, and `StoreIfNew` in `internal/gossip/cache.go`.
- Validate inbound publish payload size in `handleEnvelope` and reject/penalize messages larger than `n.config.Security.MaxMessageSizeBytes` before caching or forwarding in `internal/mesh/node.go`.
- Bound suppression growth by limiting IDs accepted per message (`maxSuppressionIDsPerMessage = 256`), pruning expired entries (`suppressionTTL = 2 * time.Minute`), and capping per-peer suppression entries (`maxSuppressionEntriesPerPeer = 1024`) with oldest-first eviction in `internal/mesh/node.go`.
- Add targeted regression tests: `TestCacheEvictsOldestWhenMaxEntriesReached`, `TestInboundPublishAboveMaxSizeIsRejected`, and `TestRememberSuppressionCapsPerPeerEntries`.

### Testing
- Ran `go test ./internal/gossip ./internal/mesh` and the test suites passed.
- Ran `gofmt -w` on modified files and re-ran `go test ./internal/gossip ./internal/mesh`, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebe04bac1c832ab5a63e6429f550dd)