### PR TITLE
fix: bound inbound transport frame sizes

### DIFF
--- a/internal/mesh/node.go
+++ b/internal/mesh/node.go
@@ -916,6 +916,10 @@ func (n *Node) readPeer(peer *peerConn) {
 		if err != nil {
 			return
 		}
+		if len(packet) > n.config.Security.MaxMessageSizeBytes {
+			n.scoring.PenalizeInvalid(peer.id)
+			return
+		}
 		var env gossip.Envelope
 		if err := json.Unmarshal(packet, &env); err != nil {
 			n.scoring.PenalizeInvalid(peer.id)

--- a/internal/transport/noise.go
+++ b/internal/transport/noise.go
@@ -316,6 +316,9 @@ func readFrame(ctx context.Context, conn net.Conn) ([]byte, error) {
 	if size == 0 {
 		return nil, nil
 	}
+	if size > maxStreamPacketSize {
+		return nil, errPacketTooLarge
+	}
 	payload := make([]byte, size)
 	if err := readRaw(ctx, conn, payload); err != nil {
 		return nil, err

--- a/internal/transport/stream.go
+++ b/internal/transport/stream.go
@@ -2,9 +2,14 @@ package transport
 
 import (
 	"encoding/binary"
+	"errors"
 	"io"
 	"net"
 )
+
+const maxStreamPacketSize uint32 = 16 * 1024 * 1024
+
+var errPacketTooLarge = errors.New("transport packet too large")
 
 type streamCarrier struct {
 	conn net.Conn
@@ -29,6 +34,9 @@ func (c *streamCarrier) ReadPacket() ([]byte, error) {
 		return nil, err
 	}
 	size := binary.BigEndian.Uint32(header)
+	if size > maxStreamPacketSize {
+		return nil, errPacketTooLarge
+	}
 	buf := make([]byte, size)
 	if _, err := io.ReadFull(c.conn, buf); err != nil {
 		return nil, err

--- a/internal/transport/stream_test.go
+++ b/internal/transport/stream_test.go
@@ -1,0 +1,57 @@
+package transport
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestStreamCarrierReadPacketRejectsOversizedFrame(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		header := make([]byte, 4)
+		binary.BigEndian.PutUint32(header, maxStreamPacketSize+1)
+		_, err := client.Write(header)
+		done <- err
+	}()
+
+	c := &streamCarrier{conn: server}
+	if _, err := c.ReadPacket(); !errors.Is(err, errPacketTooLarge) {
+		t.Fatalf("expected errPacketTooLarge, got %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out writing oversized header")
+	}
+}
+
+func TestReadFrameRejectsOversizedFrame(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		header := make([]byte, 4)
+		binary.BigEndian.PutUint32(header, maxStreamPacketSize+1)
+		_, err := client.Write(header)
+		done <- err
+	}()
+
+	if _, err := readFrame(context.Background(), server); !errors.Is(err, errPacketTooLarge) {
+		t.Fatalf("expected errPacketTooLarge, got %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out writing oversized header")
+	}
+}


### PR DESCRIPTION
### Motivation

- The transport layer accepted a peer-controlled 4-byte length prefix and allocated buffers of that size with no upper bound, allowing unauthenticated peers to trigger large allocations or OOMs. 
- The handshake path (`readFrame`) and session packet reads (`streamCarrier.ReadPacket`) were vulnerable, and inbound mesh processing unmarshalled decrypted packets before enforcing `Security.MaxMessageSizeBytes`.

### Description

- Introduce a hard upper bound `maxStreamPacketSize = 16 MiB` and an error `errPacketTooLarge` to limit inbound length-prefixed frames.
- Enforce the bound in `streamCarrier.ReadPacket` to reject oversized encrypted packets upfront.
- Enforce the same bound in `readFrame` (handshake/frame reader) to prevent oversized allocations during pre-auth handshake processing.
- Enforce `n.config.Security.MaxMessageSizeBytes` in `Node.readPeer` before calling `json.Unmarshal` to prevent large decrypted payloads from being processed.
- Add unit tests `TestStreamCarrierReadPacketRejectsOversizedFrame` and `TestReadFrameRejectsOversizedFrame` to validate oversized headers are rejected.

### Testing

- Ran `go test ./internal/transport` including `TestStreamCarrierReadPacketRejectsOversizedFrame`, `TestReadFrameRejectsOversizedFrame`, and existing handshake/encrypted packet roundtrip tests, which passed.
- Ran targeted mesh config tests `go test ./internal/mesh -run TestParseConfig*`, which passed.
- Running the full `go test ./internal/transport ./internal/mesh` in this environment surfaced a pre-existing flaky/integration failure (`TestTrackerBootstrapPeersRelayPubSubThroughTransitServer`) unrelated to the transport frame bounds change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebe088cb18832abd61d88185215b52)