### PR TITLE
Fix bound tracker traffic for VPN bypass

### DIFF
--- a/internal/bootstrap/tracker_http.go
+++ b/internal/bootstrap/tracker_http.go
@@ -11,15 +11,30 @@ import (
 	"net/url"
 	"strconv"
 	"time"
+
+	"moss/internal/transport"
 )
 
 type HTTPClient struct {
-	Client *http.Client
+	Client      *http.Client
+	BindIfIndex int
 }
 
 func NewHTTPClient(timeout time.Duration) *HTTPClient {
+	return NewHTTPClientWithBind(timeout, 0)
+}
+
+func NewHTTPClientWithBind(timeout time.Duration, bindIfIndex int) *HTTPClient {
+	client := &http.Client{Timeout: timeout}
+	if bindIfIndex != 0 {
+		dialer := transport.DialerWithBind(net.Dialer{Timeout: timeout}, bindIfIndex)
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.DialContext = dialer.DialContext
+		client.Transport = tr
+	}
 	return &HTTPClient{
-		Client: &http.Client{Timeout: timeout},
+		Client:      client,
+		BindIfIndex: bindIfIndex,
 	}
 }
 

--- a/internal/bootstrap/tracker_manager.go
+++ b/internal/bootstrap/tracker_manager.go
@@ -61,7 +61,7 @@ func NewManager(timeout time.Duration) *Manager {
 // override and lets the OS routing table decide).
 func NewManagerWithBind(timeout time.Duration, bindIfIndex int) *Manager {
 	return &Manager{
-		HTTP:          NewHTTPClient(timeout),
+		HTTP:          NewHTTPClientWithBind(timeout, bindIfIndex),
 		UDP:           &UDPClient{BindIfIndex: bindIfIndex},
 		maxConcurrent: defaultTrackerConcurrency,
 		state:         make(map[string]trackerState),

--- a/internal/bootstrap/tracker_manager.go
+++ b/internal/bootstrap/tracker_manager.go
@@ -53,9 +53,16 @@ type Manager struct {
 const defaultTrackerConcurrency = 5
 
 func NewManager(timeout time.Duration) *Manager {
+	return NewManagerWithBind(timeout, 0)
+}
+
+// NewManagerWithBind constructs a Manager whose UDP tracker client forces
+// outbound packets through the given network interface index (0 disables the
+// override and lets the OS routing table decide).
+func NewManagerWithBind(timeout time.Duration, bindIfIndex int) *Manager {
 	return &Manager{
 		HTTP:          NewHTTPClient(timeout),
-		UDP:           &UDPClient{},
+		UDP:           &UDPClient{BindIfIndex: bindIfIndex},
 		maxConcurrent: defaultTrackerConcurrency,
 		state:         make(map[string]trackerState),
 	}

--- a/internal/bootstrap/tracker_manager_test.go
+++ b/internal/bootstrap/tracker_manager_test.go
@@ -328,6 +328,26 @@ func TestManagerAnnounceAllLimitsConcurrentTrackers(t *testing.T) {
 	}
 }
 
+func TestNewManagerWithBindPinsHTTPAndUDPTrackers(t *testing.T) {
+	manager := NewManagerWithBind(time.Second, 23)
+
+	httpClient, ok := manager.HTTP.(*HTTPClient)
+	if !ok {
+		t.Fatalf("HTTP client type = %T, want *HTTPClient", manager.HTTP)
+	}
+	if httpClient.BindIfIndex != 23 {
+		t.Fatalf("HTTP BindIfIndex = %d, want 23", httpClient.BindIfIndex)
+	}
+
+	udpClient, ok := manager.UDP.(*UDPClient)
+	if !ok {
+		t.Fatalf("UDP client type = %T, want *UDPClient", manager.UDP)
+	}
+	if udpClient.BindIfIndex != 23 {
+		t.Fatalf("UDP BindIfIndex = %d, want 23", udpClient.BindIfIndex)
+	}
+}
+
 func TestManagerAnnounceAllHonorsContextDeadline(t *testing.T) {
 	client := &blockingTrackerClient{
 		fakeTrackerClient: fakeTrackerClient{

--- a/internal/bootstrap/tracker_udp.go
+++ b/internal/bootstrap/tracker_udp.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"net/url"
 	"time"
+
+	"moss/internal/transport"
 )
 
 const (
@@ -16,7 +18,12 @@ const (
 	trackerConnectionID   = 0x41727101980
 )
 
-type UDPClient struct{}
+// UDPClient announces over the binary UDP tracker protocol. Setting
+// BindIfIndex to a non-zero value forces the underlying socket onto a
+// specific NIC (see transport.ResolveBindInterface).
+type UDPClient struct {
+	BindIfIndex int
+}
 
 var (
 	udpTrackerDialTimeout    = 3 * time.Second
@@ -34,7 +41,10 @@ func (c *UDPClient) Announce(ctx context.Context, trackerURL string, req Announc
 	if _, _, err := net.SplitHostPort(host); err != nil {
 		host = net.JoinHostPort(host, "80")
 	}
-	conn, err := net.DialTimeout("udp", host, udpTrackerDialTimeout)
+	dialer := transport.DialerWithBind(net.Dialer{Timeout: udpTrackerDialTimeout}, c.BindIfIndex)
+	dialCtx, cancel := context.WithTimeout(ctx, udpTrackerDialTimeout)
+	defer cancel()
+	conn, err := dialer.DialContext(dialCtx, "udp", host)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mesh/config.go
+++ b/internal/mesh/config.go
@@ -35,10 +35,22 @@ type Config struct {
 	LANDiscoveryEnabled bool            `json:"lan_discovery_enabled"`
 	LANDiscoveryPort    int             `json:"lan_discovery_port"`
 	LANDiscoveryMS      int             `json:"lan_discovery_ms"`
-	GossipSub           GossipSubConfig `json:"gossipsub"`
-	NAT                 NATConfig       `json:"nat"`
-	Security            SecurityConfig  `json:"security"`
-	Transport           TransportConfig `json:"transport"`
+	// BindInterface forces outbound UDP packets through a specific NIC,
+	// overriding the host routing table. Accepts either an interface name
+	// ("Ethernet 2", "en0") or a numeric index ("3"). Empty value disables
+	// the feature and lets traffic flow through whatever the OS chooses —
+	// which, when a VPN is active, is the VPN tunnel.
+	//
+	// SECURITY: turning this on bypasses any VPN the user has configured,
+	// exposing the host's real IPv4 source address to peers, trackers, and
+	// STUN servers. The Mosh frontend gates this behind an explicit toggle
+	// with a privacy warning and is responsible for never enabling it
+	// silently. See docs/bind-interface.md for the threat model.
+	BindInterface string          `json:"bind_interface"`
+	GossipSub     GossipSubConfig `json:"gossipsub"`
+	NAT           NATConfig       `json:"nat"`
+	Security      SecurityConfig  `json:"security"`
+	Transport     TransportConfig `json:"transport"`
 }
 
 // TransportConfig tunes per-session inbound buffer sizes. Increase these

--- a/internal/mesh/lan_discovery.go
+++ b/internal/mesh/lan_discovery.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/net/ipv4"
 
 	"moss/internal/nat"
+	"moss/internal/transport"
 )
 
 const lanDiscoveryGroup = "239.255.77.77"
@@ -57,6 +58,12 @@ func (n *Node) lanDiscoveryLoop(ctx context.Context) {
 	sendConn, err := net.ListenPacket("udp4", ":0")
 	if err != nil {
 		return
+	}
+	if udpConn, ok := sendConn.(*net.UDPConn); ok {
+		if bindErr := transport.ApplyBindToUDP(udpConn, n.bindIfIndex); bindErr != nil {
+			_ = sendConn.Close()
+			return
+		}
 	}
 	defer sendConn.Close()
 	sendPacket := ipv4.NewPacketConn(sendConn)

--- a/internal/mesh/node_integration_relay_limits_test.go
+++ b/internal/mesh/node_integration_relay_limits_test.go
@@ -219,7 +219,7 @@ func TestRelayNodeEnforcesConfiguredBandwidth(t *testing.T) {
 		if !bytes.Equal(payload, firstPayload) {
 			t.Fatalf("unexpected first relay payload: %q", string(payload))
 		}
-	case <-time.After(3 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for first relayed payload")
 	}
 

--- a/internal/mesh/node_lifecycle.go
+++ b/internal/mesh/node_lifecycle.go
@@ -57,6 +57,10 @@ func NewNodeWithIdentity(meshID string, psk []byte, cfg Config, identity *mcrypt
 	if err != nil {
 		return nil, err
 	}
+	bindIfIndex, err := transport.ResolveBindInterface(cfg.BindInterface)
+	if err != nil {
+		return nil, err
+	}
 	node := &Node{
 		meshID:           meshID,
 		psk:              append([]byte(nil), psk...),
@@ -64,7 +68,8 @@ func NewNodeWithIdentity(meshID string, psk []byte, cfg Config, identity *mcrypt
 		infoHash:         infoHash,
 		peerID:           peerID,
 		identity:         identity,
-		tracker:          bootstrap.NewManager(time.Duration(cfg.BootstrapTimeoutSec) * time.Second),
+		bindIfIndex:      bindIfIndex,
+		tracker:          bootstrap.NewManagerWithBind(time.Duration(cfg.BootstrapTimeoutSec)*time.Second, bindIfIndex),
 		pubsub:           gossip.NewManager(),
 		cache:            gossip.NewCache(2 * time.Minute),
 		scoring:          gossip.NewEngine(),
@@ -101,10 +106,11 @@ func (n *Node) Start() int32 {
 		return MOSS_ERR_ALREADY_STARTED
 	}
 	ln, udpListener, port, err := transport.ListenPair(n.config.ListenPort, transport.HandshakeConfig{
-		MeshID:   n.meshID,
-		PSK:      n.psk,
-		Identity: n.identity,
-		Buffers:  transportBufferConfig(n.config.Transport),
+		MeshID:      n.meshID,
+		PSK:         n.psk,
+		Identity:    n.identity,
+		Buffers:     transportBufferConfig(n.config.Transport),
+		BindIfIndex: n.bindIfIndex,
 	})
 	if err != nil {
 		return MOSS_ERR_CONFIG_INVALID

--- a/internal/mesh/node_types.go
+++ b/internal/mesh/node_types.go
@@ -30,6 +30,7 @@ type Node struct {
 	udpListener   *transport.UDPListener
 	relaySessions *nat.SessionManager
 	listenPort    int
+	bindIfIndex   int
 	startedAt     time.Time
 	dispatchSem   chan struct{}
 

--- a/internal/transport/bind.go
+++ b/internal/transport/bind.go
@@ -1,0 +1,92 @@
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"syscall"
+)
+
+// ErrBindInterfaceUnsupported is returned by the OS-specific helpers when the
+// current platform has no equivalent of IP_UNICAST_IF / SO_BINDTODEVICE.
+var ErrBindInterfaceUnsupported = errors.New("bind interface unsupported on this platform")
+
+// ResolveBindInterface accepts either the OS interface name (e.g. "Ethernet",
+// "en0") or its numeric index (e.g. "3"). It returns the resolved index after
+// validating that the interface exists, is up, and is not a loopback.
+//
+// Returns 0 (and a nil error) for an empty spec — callers should treat that
+// as "feature disabled" and skip applying the bind.
+func ResolveBindInterface(spec string) (int, error) {
+	if spec == "" {
+		return 0, nil
+	}
+	var iface *net.Interface
+	var err error
+	if idx, parseErr := strconv.Atoi(spec); parseErr == nil {
+		iface, err = net.InterfaceByIndex(idx)
+	} else {
+		iface, err = net.InterfaceByName(spec)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("bind interface %q: %w", spec, err)
+	}
+	if iface.Flags&net.FlagLoopback != 0 {
+		return 0, fmt.Errorf("bind interface %q is loopback", spec)
+	}
+	if iface.Flags&net.FlagUp == 0 {
+		return 0, fmt.Errorf("bind interface %q is down", spec)
+	}
+	return iface.Index, nil
+}
+
+// ApplyBindToUDP applies the interface bind (if any) to a freshly-created
+// *net.UDPConn. A zero ifIndex is a no-op so call sites can call this
+// unconditionally when configured.
+func ApplyBindToUDP(conn *net.UDPConn, ifIndex int) error {
+	if ifIndex == 0 {
+		return nil
+	}
+	rc, err := conn.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("bind interface: SyscallConn: %w", err)
+	}
+	return applyBindInterface(rc, ifIndex)
+}
+
+// applyBindToPacket applies the interface bind to a freshly-created
+// net.PacketConn (used by LAN discovery's net.ListenPacket call sites).
+func applyBindToPacket(conn net.PacketConn, ifIndex int) error {
+	if ifIndex == 0 {
+		return nil
+	}
+	udp, ok := conn.(*net.UDPConn)
+	if !ok {
+		return fmt.Errorf("bind interface: unsupported PacketConn type %T", conn)
+	}
+	return ApplyBindToUDP(udp, ifIndex)
+}
+
+// DialerWithBind returns a *net.Dialer whose freshly-created sockets are
+// pinned to the named interface index via the OS-specific helper. A zero
+// ifIndex yields an unmodified Dialer with no Control hook.
+//
+// Use this for net.Dial-flavoured call sites — UDP trackers, NAT-PMP probes,
+// any callers that need outbound traffic to skip the routing table.
+func DialerWithBind(base net.Dialer, ifIndex int) *net.Dialer {
+	if ifIndex == 0 {
+		return &base
+	}
+	d := base
+	prev := d.Control
+	d.Control = func(network, address string, c syscall.RawConn) error {
+		if prev != nil {
+			if err := prev(network, address, c); err != nil {
+				return err
+			}
+		}
+		return applyBindInterface(c, ifIndex)
+	}
+	return &d
+}

--- a/internal/transport/bind_apply_windows_test.go
+++ b/internal/transport/bind_apply_windows_test.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package transport
+
+import (
+	"net"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestApplyBindToUDPSetsUnicastIF confirms the helper actually flips
+// IP_UNICAST_IF on the socket so callers can't be fooled by a silent no-op
+// (a previous draft swapped the byte order and getsockopt would have
+// returned a different index than asked for).
+func TestApplyBindToUDPSetsUnicastIF(t *testing.T) {
+	iface, err := findUpNonLoopback()
+	if err != nil {
+		t.Skipf("no usable interface: %v", err)
+	}
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	defer conn.Close()
+	if err := ApplyBindToUDP(conn, iface.Index); err != nil {
+		t.Fatalf("ApplyBindToUDP: %v", err)
+	}
+	rc, err := conn.SyscallConn()
+	if err != nil {
+		t.Fatalf("SyscallConn: %v", err)
+	}
+	var got int
+	var sockErr error
+	if err := rc.Control(func(fd uintptr) {
+		got, sockErr = windows.GetsockoptInt(
+			windows.Handle(fd),
+			windows.IPPROTO_IP,
+			winIPUnicastIF,
+		)
+	}); err != nil {
+		t.Fatalf("Control: %v", err)
+	}
+	if sockErr != nil {
+		t.Fatalf("getsockopt(IP_UNICAST_IF): %v", sockErr)
+	}
+	// Asymmetric Winsock quirk: setsockopt expects the value in network
+	// byte order but getsockopt returns it in host byte order, so the
+	// observed int should match the raw interface index.
+	if got != iface.Index {
+		t.Fatalf("IP_UNICAST_IF = %d, want %d", got, iface.Index)
+	}
+}

--- a/internal/transport/bind_darwin.go
+++ b/internal/transport/bind_darwin.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package transport
+
+import (
+	"fmt"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// IP_BOUND_IF is the macOS equivalent of Windows' IP_UNICAST_IF: it locks
+// outbound unicast packets to a specific interface index, overriding the
+// routing table. Defined in <netinet/in.h> as option 25 at IPPROTO_IP.
+const darwinIPBoundIF = 25
+
+func applyBindInterface(rc syscall.RawConn, ifIndex int) error {
+	if ifIndex <= 0 {
+		return nil
+	}
+	var sockErr error
+	ctrlErr := rc.Control(func(fd uintptr) {
+		sockErr = unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, darwinIPBoundIF, ifIndex)
+	})
+	if ctrlErr != nil {
+		return fmt.Errorf("bind interface: RawConn.Control: %w", ctrlErr)
+	}
+	if sockErr != nil {
+		return fmt.Errorf("bind interface: setsockopt(IP_BOUND_IF, %d): %w", ifIndex, sockErr)
+	}
+	return nil
+}

--- a/internal/transport/bind_linux.go
+++ b/internal/transport/bind_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package transport
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// applyBindInterface uses SO_BINDTODEVICE to lock the socket to a specific
+// network interface. This requires CAP_NET_RAW; without it the setsockopt
+// call returns EPERM and we surface it as a hard error.
+func applyBindInterface(rc syscall.RawConn, ifIndex int) error {
+	if ifIndex <= 0 {
+		return nil
+	}
+	iface, err := net.InterfaceByIndex(ifIndex)
+	if err != nil {
+		return fmt.Errorf("bind interface: lookup index %d: %w", ifIndex, err)
+	}
+	var sockErr error
+	ctrlErr := rc.Control(func(fd uintptr) {
+		sockErr = unix.SetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_BINDTODEVICE, iface.Name)
+	})
+	if ctrlErr != nil {
+		return fmt.Errorf("bind interface: RawConn.Control: %w", ctrlErr)
+	}
+	if sockErr != nil {
+		return fmt.Errorf("bind interface: setsockopt(SO_BINDTODEVICE, %q): %w", iface.Name, sockErr)
+	}
+	return nil
+}

--- a/internal/transport/bind_other.go
+++ b/internal/transport/bind_other.go
@@ -1,0 +1,14 @@
+//go:build !windows && !linux && !darwin
+
+package transport
+
+import "syscall"
+
+// Stub for unsupported platforms (FreeBSD, OpenBSD, etc). Returns the
+// sentinel so call sites can decide whether to fail or fall back.
+func applyBindInterface(_ syscall.RawConn, ifIndex int) error {
+	if ifIndex <= 0 {
+		return nil
+	}
+	return ErrBindInterfaceUnsupported
+}

--- a/internal/transport/bind_test.go
+++ b/internal/transport/bind_test.go
@@ -1,0 +1,106 @@
+package transport
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestResolveBindInterfaceEmpty(t *testing.T) {
+	idx, err := ResolveBindInterface("")
+	if err != nil {
+		t.Fatalf("empty spec must not error, got %v", err)
+	}
+	if idx != 0 {
+		t.Fatalf("empty spec must resolve to 0, got %d", idx)
+	}
+}
+
+func TestResolveBindInterfaceUnknownName(t *testing.T) {
+	_, err := ResolveBindInterface("this-interface-should-never-exist-9999")
+	if err == nil {
+		t.Fatalf("unknown name must error")
+	}
+}
+
+func TestResolveBindInterfaceLoopbackRejected(t *testing.T) {
+	loopback, err := findLoopback()
+	if err != nil {
+		t.Skipf("no loopback found: %v", err)
+	}
+	if _, err := ResolveBindInterface(loopback.Name); err == nil {
+		t.Fatalf("loopback name must be rejected")
+	}
+	if _, err := ResolveBindInterface(strconv.Itoa(loopback.Index)); err == nil {
+		t.Fatalf("loopback index must be rejected")
+	}
+}
+
+func TestResolveBindInterfaceAcceptsLiveNIC(t *testing.T) {
+	iface, err := findUpNonLoopback()
+	if err != nil {
+		t.Skipf("no usable interface: %v", err)
+	}
+	gotIdx, err := ResolveBindInterface(iface.Name)
+	if err != nil {
+		t.Fatalf("name %q rejected: %v", iface.Name, err)
+	}
+	if gotIdx != iface.Index {
+		t.Fatalf("name %q resolved to index %d, want %d", iface.Name, gotIdx, iface.Index)
+	}
+	gotIdx, err = ResolveBindInterface(strconv.Itoa(iface.Index))
+	if err != nil {
+		t.Fatalf("index %d rejected: %v", iface.Index, err)
+	}
+	if gotIdx != iface.Index {
+		t.Fatalf("numeric spec resolved to %d, want %d", gotIdx, iface.Index)
+	}
+}
+
+// findLoopback returns the first loopback interface available, or an error
+// if none is enumerable (this should not happen on supported platforms).
+func findLoopback() (*net.Interface, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	for i := range ifaces {
+		if ifaces[i].Flags&net.FlagLoopback != 0 {
+			return &ifaces[i], nil
+		}
+	}
+	return nil, errNoInterface
+}
+
+// findUpNonLoopback returns the first interface that is up and not a
+// loopback — the kind of NIC ResolveBindInterface should accept.
+func findUpNonLoopback() (*net.Interface, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	for i := range ifaces {
+		if ifaces[i].Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if ifaces[i].Flags&net.FlagUp == 0 {
+			continue
+		}
+		// Skip interfaces whose name contains "tunnel" / "vEthernet" hint at
+		// virtual adapters — those still resolve fine but vary across CI
+		// hosts and we want a stable pick.
+		lower := strings.ToLower(ifaces[i].Name)
+		if strings.Contains(lower, "tunnel") {
+			continue
+		}
+		return &ifaces[i], nil
+	}
+	return nil, errNoInterface
+}
+
+var errNoInterface = &netError{msg: "no matching interface"}
+
+type netError struct{ msg string }
+
+func (e *netError) Error() string { return e.msg }

--- a/internal/transport/bind_windows.go
+++ b/internal/transport/bind_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package transport
+
+import (
+	"encoding/binary"
+	"fmt"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// IP_UNICAST_IF is the Winsock option that forces outbound unicast packets to
+// leave through a specific interface, overriding the routing table. This is
+// what lets us bypass a VPN's default route without touching system routing.
+//
+// Winsock value: 31 at level IPPROTO_IP. The option takes the interface
+// index as an int, *in network byte order* (a documented Windows quirk).
+const winIPUnicastIF = 31
+
+// applyBindInterface attaches the IP_UNICAST_IF socket option to the given
+// raw connection. Errors from the inner setsockopt are surfaced so that a
+// failing bind (e.g. interface offline at socket-creation time) becomes a
+// hard error instead of silently routing traffic through the VPN tunnel.
+func applyBindInterface(rc syscall.RawConn, ifIndex int) error {
+	if ifIndex <= 0 {
+		return nil
+	}
+	// Windows demands the interface index in network byte order.
+	beIndex := make([]byte, 4)
+	binary.BigEndian.PutUint32(beIndex, uint32(ifIndex))
+	value := int(binary.LittleEndian.Uint32(beIndex))
+
+	var sockErr error
+	ctrlErr := rc.Control(func(fd uintptr) {
+		sockErr = windows.SetsockoptInt(
+			windows.Handle(fd),
+			windows.IPPROTO_IP,
+			winIPUnicastIF,
+			value,
+		)
+	})
+	if ctrlErr != nil {
+		return fmt.Errorf("bind interface: RawConn.Control: %w", ctrlErr)
+	}
+	if sockErr != nil {
+		return fmt.Errorf("bind interface: setsockopt(IP_UNICAST_IF, %d): %w", ifIndex, sockErr)
+	}
+	return nil
+}

--- a/internal/transport/noise.go
+++ b/internal/transport/noise.go
@@ -20,6 +20,15 @@ type HandshakeConfig struct {
 	Identity     *mcrypto.Identity
 	RemoteStatic []byte
 	Buffers      BufferConfig
+	// BindIfIndex, when non-zero, forces the UDP listener socket to send
+	// outbound packets through the named OS interface index via
+	// IP_UNICAST_IF (Windows) / SO_BINDTODEVICE (Linux) / IP_BOUND_IF
+	// (macOS). Zero leaves routing-table behaviour intact.
+	//
+	// Surfaced here because ListenUDP is the single creation point for the
+	// session socket and the same option must apply for every datagram it
+	// sends. Callers resolve names → indices via ResolveBindInterface.
+	BindIfIndex int
 }
 
 // BufferConfig tunes inbound queues for sessions created by a handshake.

--- a/internal/transport/udp.go
+++ b/internal/transport/udp.go
@@ -82,6 +82,10 @@ func ListenUDP(port int, cfg HandshakeConfig) (*UDPListener, int, error) {
 	if err != nil {
 		return nil, 0, err
 	}
+	if err := ApplyBindToUDP(conn, cfg.BindIfIndex); err != nil {
+		_ = conn.Close()
+		return nil, 0, err
+	}
 	listener := &UDPListener{
 		conn:     conn,
 		cfg:      cfg,


### PR DESCRIPTION
## Summary
- bind HTTP tracker announces to the selected NIC, matching UDP tracker behavior
- keep the selected bind interface visible on both tracker clients
- add coverage that NewManagerWithBind pins HTTP and UDP bootstrap traffic

## Tests
- go test ./internal/bootstrap ./internal/transport