### PR TITLE
fix(transport): resolve STUN/peer addrs as udp4 to match the v4 listener

### DIFF
--- a/internal/transport/udp.go
+++ b/internal/transport/udp.go
@@ -134,7 +134,9 @@ func (l *UDPListener) DialContext(ctx context.Context, addr string) (*Session, e
 }
 
 func (l *UDPListener) DialPeerContext(ctx context.Context, addr string, remoteStatic []byte) (*Session, error) {
-	remote, err := net.ResolveUDPAddr("udp", addr)
+	// udp4: peers are dialed on the IPv4-only listener socket, so the address
+	// must resolve to IPv4 to match (mesh peer addrs are always v4 host:port).
+	remote, err := net.ResolveUDPAddr("udp4", addr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transport/udp_observe.go
+++ b/internal/transport/udp_observe.go
@@ -9,7 +9,10 @@ import (
 )
 
 func (l *UDPListener) ObserveContext(ctx context.Context, addr string) (string, error) {
-	remote, err := net.ResolveUDPAddr("udp", addr)
+	// udp4: the listener socket is IPv4-only (net.ListenUDP("udp4", ...)), so a
+	// resolved address must be IPv4. Plain "udp" lets the resolver return an
+	// IPv6 address, which then cannot be sent on the v4 socket.
+	remote, err := net.ResolveUDPAddr("udp4", addr)
 	if err != nil {
 		return "", err
 	}
@@ -52,7 +55,12 @@ func (l *UDPListener) ObserveContext(ctx context.Context, addr string) (string, 
 }
 
 func (l *UDPListener) ObserveSTUNContext(ctx context.Context, addr string) (string, error) {
-	remote, err := net.ResolveUDPAddr("udp", addr)
+	// udp4: STUN observation must go out over the IPv4-only listener socket.
+	// A STUN hostname (e.g. stun.l.google.com) resolves to both A and AAAA; with
+	// plain "udp" the resolver can hand back the IPv6 address, and on an
+	// IPv4-only-egress host the STUN request then silently fails, leaving NAT
+	// type stuck at "unknown" (node never promotes to SuperNode).
+	remote, err := net.ResolveUDPAddr("udp4", addr)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Problem

The UDP transport binds **udp4** (`net.ListenUDP("udp4", ...)` in `udp.go`), but three call sites resolved addresses with `net.ResolveUDPAddr("udp", ...)`:
- `udp_observe.go` `ObserveSTUNContext` — STUN server (hostname)
- `udp_observe.go` `ObserveContext` — peer observe
- `udp.go` `DialPeerContext` — peer dial

For a dual-stack STUN hostname (e.g. `stun.l.google.com`) the resolver can return the **IPv6** address, which then cannot be sent on the v4 socket. On an **IPv4-only-egress host** (public IPv4 on NIC, no IPv6 default route — common on VPS and many RU networks) the STUN request silently fails, so external-address observation never completes and NAT type stays `"unknown"`. A genuinely public node then never promotes to SuperNode via the STUN path.

## Fix

Resolve all three as `"udp4"`, matching the udp4 listener. The transport is IPv4-only by design, so this is strictly correct — no IPv6 regression (there was no working IPv6 transport path).

## Verified

- `go build ./...`, `go vet ./internal/transport/` clean.
- `go test ./internal/transport/ ./internal/nat/` — 55 pass.
- Reproduced on a real IPv4-only Hetzner host: with the fix built in, a spore on `moss-relay/1` promotes to `nat_type: public` / `supernode_ready: true` the moment a peer connects and probes it (peer-observe path); the STUN path no longer stalls on IPv6.

Found while bringing up the first public relay spore (universal-relay S3 ops).