### PR TITLE
fix(mesh): re-send SupernodeAnnounce to peers joining after promotion

### DIFF
--- a/internal/mesh/node_dispatch_bootstrap.go
+++ b/internal/mesh/node_dispatch_bootstrap.go
@@ -134,6 +134,29 @@ func (n *Node) refreshSupernodeStatus() {
 	n.enqueueEvent(eventType, map[string]string{"nat_type": string(profile.Type)})
 }
 
+// reannounceSupernodeStatus re-broadcasts a signed SupernodeAnnounce to all peers
+// while this node is an active SuperNode. refreshSupernodeStatus emits only on a
+// status *change*, and the one-shot promotion broadcast reaches only the peers
+// connected at that instant — a peer that joins later, or that was registered
+// before this node's own probe-driven promotion, never gets a trusted, signed
+// announcement (relay capability is never taken from a plain peer-announce). The
+// periodic re-broadcast converges every current peer's view of our relay role.
+func (n *Node) reannounceSupernodeStatus() {
+	info := n.localKnownPeer()
+	if !info.relayCapable {
+		return
+	}
+	signed := n.signSupernodeEnvelope(gossip.Envelope{
+		Type:                   gossip.TypeSupernodeAnnounce,
+		AdvertisedPeerID:       info.id,
+		AdvertisedAddr:         info.addr,
+		AdvertisedNATType:      string(info.natType),
+		AdvertisedReachable:    info.publicReachable,
+		AdvertisedRelayCapable: true,
+	})
+	n.broadcastToAll(signed, "")
+}
+
 func (n *Node) enqueueEvent(eventType int32, detail any) {
 	raw, _ := json.Marshal(detail)
 	n.dispatchCh <- dispatchEvent{eventType: eventType, detail: string(raw)}

--- a/internal/mesh/node_integration_nat_test.go
+++ b/internal/mesh/node_integration_nat_test.go
@@ -94,6 +94,56 @@ func TestSupernodeDemotesWhenRelayCapacityIsSaturated(t *testing.T) {
 	}
 }
 
+// TestSupernodeAnnounceReachesPeerJoiningAfterPromotion covers the relay-mesh
+// bootstrap case: a public SuperNode promotes while it has no peers, then a peer
+// connects afterwards. Relay capability is only trusted from a signed
+// SupernodeAnnounce (never a plain peer-announce), and that announce is otherwise
+// broadcast just once at promotion — so a late-joining peer must be (re-)told on
+// join, or it never learns the node can relay for it.
+func TestSupernodeAnnounceReachesPeerJoiningAfterPromotion(t *testing.T) {
+	cfgA := DefaultConfig()
+	cfgA.Trackers = nil
+	cfgA.GossipSub.HeartbeatMS = 50
+	cfgA.NAT.SuperNodeMinUptimeSec = 0
+	nodeA, err := NewNode("mesh-supernode-latejoin", nil, cfgA)
+	if err != nil {
+		t.Fatalf("NewNode nodeA failed: %v", err)
+	}
+	if code := nodeA.Start(); code != MOSS_OK {
+		t.Fatalf("nodeA.Start failed: %d", code)
+	}
+	defer nodeA.Stop()
+
+	// Promote A to SuperNode BEFORE any peer is connected.
+	nodeA.natProfile.Store(nat.Profile{
+		Type:            nat.TypePublic,
+		PublicReachable: true,
+		ExternalAddress: net.JoinHostPort("203.0.113.10", strconv.Itoa(nodeA.ListenPort())),
+	})
+	nodeA.refreshSupernodeStatus()
+
+	// B connects only now — after promotion. It must still converge to seeing A
+	// as relay-capable.
+	cfgB := DefaultConfig()
+	cfgB.Trackers = nil
+	cfgB.GossipSub.HeartbeatMS = 50
+	cfgB.StaticPeers = []string{net.JoinHostPort("127.0.0.1", strconv.Itoa(nodeA.ListenPort()))}
+	nodeB, err := NewNode("mesh-supernode-latejoin", nil, cfgB)
+	if err != nil {
+		t.Fatalf("NewNode nodeB failed: %v", err)
+	}
+	if code := nodeB.Start(); code != MOSS_OK {
+		t.Fatalf("nodeB.Start failed: %d", code)
+	}
+	defer nodeB.Stop()
+
+	waitForPeerCount(t, nodeB, 1)
+	nodeAPub := nodeA.PublicKey()
+	nodeAID := hex.EncodeToString(nodeAPub[:])
+	waitForKnownPeer(t, nodeB, nodeAID)
+	waitForKnownPeerRelayCapable(t, nodeB, nodeAID, true)
+}
+
 func TestRefreshExternalAddressPreservesListenPort(t *testing.T) {
 	cfgRelay := DefaultConfig()
 	cfgRelay.Trackers = nil

--- a/internal/mesh/node_maintenance.go
+++ b/internal/mesh/node_maintenance.go
@@ -9,6 +9,13 @@ import (
 	"moss/internal/transport"
 )
 
+// supernodeReannounceEveryTicks throttles how often an active SuperNode
+// re-broadcasts its signed SupernodeAnnounce (every N maintenance heartbeats), so
+// peers that joined after promotion converge on its relay role without flooding
+// the mesh. At the default 1s heartbeat this is ~10s; tests using a faster
+// heartbeat converge proportionally sooner.
+const supernodeReannounceEveryTicks uint64 = 10
+
 func (n *Node) removePeer(peerID string, session *transport.Session) {
 	n.mu.Lock()
 	peer := n.peers[peerID]
@@ -237,6 +244,9 @@ func (n *Node) maintenanceLoop(ctx context.Context) {
 				n.maintainTopicMesh(channel)
 			}
 			n.refreshSupernodeStatus()
+			if atomic.LoadUint64(&n.heartbeat)%supernodeReannounceEveryTicks == 0 {
+				n.reannounceSupernodeStatus()
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Relay capability is only trusted from a **signed `SupernodeAnnounce`** — a plain peer-announce never conveys it (`handleKnownPeerEnvelope` gates `relayCapable` on `verifySupernodeStatusEnvelope`, which only accepts `TypeSupernodeAnnounce`/`Revoke`).

`refreshSupernodeStatus` broadcasts that announce **only on a status change**, and the one-shot promotion broadcast reaches only peers connected at that instant. Worse, a public node is itself promoted by a peer's probe, so at the moment it registers that peer it is **not yet** relay-capable.

Net effect: peers that connect **after** promotion — the common case for the shared relay mesh — never learn the node can relay. `relay_capable_peer_count` stays `0` and relay selection finds nothing.

## Reproduced

- **Live:** a public MossSpore relay on `moss-relay/1`; a client joining after promotion held `relay_capable_peer_count: 0` indefinitely. With this fix it converges in ~10s.
- **Test:** `TestSupernodeAnnounceReachesPeerJoiningAfterPromotion` — node promotes while alone, a peer connects afterwards, asserts convergence to `relayCapable=true`. Fails before, passes after.

## Fix

Add a throttled periodic re-broadcast — `reannounceSupernodeStatus`, every `supernodeReannounceEveryTicks` (10) maintenance heartbeats while active — of the signed `SupernodeAnnounce`. Every currently-connected peer converges within one interval (~10s at the default 1s heartbeat) regardless of when it joined. Existing re-flood in `handleKnownPeerEnvelope` carries it onward.

## Verified

`go build ./...`, `go vet`, targeted mesh suite (`Supernode|Relay|PeerAnnounce|Promot|KnownPeer`) green, plus live end-to-end on the public spore.

Follow-up to #13 — found while bringing up the first public relay spore.