### PR TITLE
fix(mesh): let stale duplicate connections yield to fresh reconnects

### DIFF
--- a/internal/mesh/duplicate_conn_test.go
+++ b/internal/mesh/duplicate_conn_test.go
@@ -1,0 +1,29 @@
+package mesh
+
+import "testing"
+
+// After a NAT rebind the peer reconnects in the same direction from a new
+// source port; the fresh connection must win over a stale (ping-missing)
+// entry, while a healthy duplicate still follows the direction rule.
+func TestYieldsToNewConnection(t *testing.T) {
+	const local = "aa"
+	const remote = "bb" // local < remote: the direction rule wants our outbound
+
+	cases := []struct {
+		name        string
+		existing    *peerConn
+		newOutbound bool
+		want        bool
+	}{
+		{"healthy same-direction duplicate is kept", &peerConn{id: remote, outbound: false}, false, false},
+		{"stale same-direction duplicate yields", &peerConn{id: remote, outbound: false, pingMisses: 1}, false, true},
+		{"stale opposite-direction duplicate yields regardless of rule", &peerConn{id: remote, outbound: true, pingMisses: 3}, false, true},
+		{"healthy opposite-direction follows rule: favored new wins", &peerConn{id: remote, outbound: false}, true, true},
+		{"healthy opposite-direction follows rule: disfavored new loses", &peerConn{id: remote, outbound: true}, false, false},
+	}
+	for _, tc := range cases {
+		if got := yieldsToNewConnection(local, tc.existing, tc.newOutbound); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/mesh/node_accept.go
+++ b/internal/mesh/node_accept.go
@@ -249,7 +249,7 @@ func (n *Node) registerPeer(session *transport.Session, outbound bool) {
 		if existing.relayed {
 			replacedPeer = existing
 		} else {
-			if !shouldReplaceDuplicatePeer(n.localPeerID(), peerID, existing.outbound, outbound) {
+			if !yieldsToNewConnection(n.localPeerID(), existing, outbound) {
 				n.mu.Unlock()
 				_ = session.Close()
 				return
@@ -397,6 +397,20 @@ func shouldReplaceDuplicatePeer(localPeerID, remotePeerID string, existingOutbou
 	}
 	wantOutbound := localPeerID < remotePeerID
 	return newOutbound == wantOutbound
+}
+
+// yieldsToNewConnection reports whether an existing direct connection for the
+// same peer should give way to a freshly handshaked one. A stale existing
+// connection (at least one missed ping) always yields: after a NAT rebind the
+// peer reconnects from a new source port in the SAME direction, and the
+// direction-only dedup would discard the live connection and keep the dead one
+// until the ping-miss prune fires. A healthy existing connection falls back to
+// the deterministic direction rule.
+func yieldsToNewConnection(localPeerID string, existing *peerConn, newOutbound bool) bool {
+	if existing.pingMisses > 0 {
+		return true
+	}
+	return shouldReplaceDuplicatePeer(localPeerID, existing.id, existing.outbound, newOutbound)
 }
 
 func (n *Node) readPeer(peer *peerConn) {


### PR DESCRIPTION
## Problem
After a NAT rebind a peer redials from a new source port in the **same direction**. `shouldReplaceDuplicatePeer` only replaces opposite-direction duplicates, so the fresh, fully-handshaked connection was closed and the dead one kept until the ping-miss prune fired — a dead window of tens of seconds per rebind. Observed live during the 2026-07-13 DM incident (peer behind an unstable VPN NAT reconnecting every ~40s).

## Fix
`yieldsToNewConnection`: an existing connection with `pingMisses > 0` always yields to the freshly handshaked one (same crypto identity — the new session passed the full noise handshake). Healthy duplicates keep the deterministic direction rule unchanged.

## Tests
`TestYieldsToNewConnection` covers stale-yield (both directions) and preserves the healthy-duplicate direction-rule behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)