### PR TITLE
feat(mesh): explicit peer targets + neutral dial ranking

### DIFF
--- a/cmd/moss-ffi/main.go
+++ b/cmd/moss-ffi/main.go
@@ -197,6 +197,18 @@ func Moss_Connect(handle C.MossHandle, addr *C.char) C.int32_t {
 	return C.int32_t(node.Connect(C.GoString(addr)))
 }
 
+//export Moss_ConnectToPeer
+func Moss_ConnectToPeer(handle C.MossHandle, peerID *C.char) C.int32_t {
+	node, code := getNode(int64(handle))
+	if code != mesh.MOSS_OK {
+		return C.int32_t(code)
+	}
+	if peerID == nil {
+		return C.int32_t(mesh.MOSS_ERR_CONFIG_INVALID)
+	}
+	return C.int32_t(node.ConnectToPeer(C.GoString(peerID)))
+}
+
 //export Moss_Unsubscribe
 func Moss_Unsubscribe(handle C.MossHandle, channel *C.char) C.int32_t {
 	node, code := getNode(int64(handle))

--- a/internal/mesh/explicit_target_test.go
+++ b/internal/mesh/explicit_target_test.go
@@ -1,0 +1,109 @@
+package mesh
+
+import (
+	"net"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func startExplicitTargetNode(t *testing.T, name string) *Node {
+	t.Helper()
+	cfg := isolatedTestConfig(name)
+	cfg.ListenPort = 0
+	cfg.Security.HandshakeTimeoutSec = 2
+	node, err := NewNode("mesh-explicit-target", nil, cfg)
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+	if code := node.Start(); code != MOSS_OK {
+		t.Fatalf("Start failed: %d", code)
+	}
+	t.Cleanup(func() { node.Stop() })
+	return node
+}
+
+func injectKnownPeer(node *Node, peerID string, port int) {
+	node.mu.Lock()
+	node.knownPeers[peerID] = knownPeer{
+		id:              peerID,
+		addr:            net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
+		verified:        true,
+		publicReachable: true,
+		lastSeen:        time.Now(),
+	}
+	node.mu.Unlock()
+}
+
+func waitForConnectedPeer(t *testing.T, node *Node, peerID string, dur time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(dur)
+	for time.Now().Before(deadline) {
+		node.mu.RLock()
+		_, connected := node.peers[peerID]
+		node.mu.RUnlock()
+		if connected {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("node never connected to explicit target %s; info=%s", peerID, node.MeshInfoJSON())
+}
+
+func TestConnectToPeerValidatesInput(t *testing.T) {
+	cfg := isolatedTestConfig("explicit-validate")
+	node, err := NewNode("mesh-explicit-target", nil, cfg)
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+	if code := node.ConnectToPeer("not-a-peer-id"); code != MOSS_ERR_CONFIG_INVALID {
+		t.Fatalf("malformed id: got %d, want MOSS_ERR_CONFIG_INVALID", code)
+	}
+	if code := node.ConnectToPeer(node.localPeerID()); code != MOSS_ERR_CONFIG_INVALID {
+		t.Fatalf("self id: got %d, want MOSS_ERR_CONFIG_INVALID", code)
+	}
+	otherID := node.localPeerID()
+	flipped := []byte(otherID)
+	if flipped[0] == 'a' {
+		flipped[0] = 'b'
+	} else {
+		flipped[0] = 'a'
+	}
+	if code := node.ConnectToPeer(string(flipped)); code != MOSS_ERR_NOT_STARTED {
+		t.Fatalf("valid id on stopped node: got %d, want MOSS_ERR_NOT_STARTED", code)
+	}
+}
+
+// The glare rule forbids the higher-id public node from dialing a public peer
+// (it waits for the inbound dial), and the discovery ranking may never select
+// the counterpart at all. An explicit target must bypass both: whichever node
+// calls ConnectToPeer connects, regardless of id ordering.
+func TestConnectToPeerReachesKnownPeerDespiteGlareOrdering(t *testing.T) {
+	a := startExplicitTargetNode(t, "explicit-target")
+	b := startExplicitTargetNode(t, "explicit-target")
+
+	caller, target := a, b
+	if caller.localPeerID() < target.localPeerID() {
+		caller, target = target, caller
+	}
+	injectKnownPeer(caller, target.localPeerID(), target.ListenPort())
+
+	if code := caller.ConnectToPeer(target.localPeerID()); code != MOSS_OK {
+		t.Fatalf("ConnectToPeer failed: %d", code)
+	}
+	waitForConnectedPeer(t, caller, target.localPeerID(), 8*time.Second)
+}
+
+// A target registered before its announce is known must be retried by the
+// maintenance loop and connect once the peer appears in knownPeers.
+func TestConnectToPeerRetriesUntilPeerBecomesKnown(t *testing.T) {
+	a := startExplicitTargetNode(t, "explicit-retry")
+	b := startExplicitTargetNode(t, "explicit-retry")
+
+	if code := a.ConnectToPeer(b.localPeerID()); code != MOSS_OK {
+		t.Fatalf("ConnectToPeer failed: %d", code)
+	}
+	time.Sleep(300 * time.Millisecond)
+	injectKnownPeer(a, b.localPeerID(), b.ListenPort())
+	waitForConnectedPeer(t, a, b.localPeerID(), 12*time.Second)
+}

--- a/internal/mesh/node_explicit_targets.go
+++ b/internal/mesh/node_explicit_targets.go
@@ -1,0 +1,72 @@
+package mesh
+
+import "time"
+
+// ConnectToPeer registers peerID as an explicit priority target: the node
+// dials it immediately and the maintenance loop keeps retrying (direct first,
+// relay fallback) until a connection exists. Explicit targets bypass the
+// discovery ranking and the public-public glare rule — those govern organic
+// mesh growth, while an explicit target is the application saying "this
+// specific peer matters" (e.g. a DM counterpart on the room-blind substrate,
+// which organic discovery would only ever reach by chance). The registration
+// survives disconnects and is dropped on Stop.
+func (n *Node) ConnectToPeer(peerID string) int32 {
+	if len(peerID) != 64 || peerID == n.localPeerID() {
+		return MOSS_ERR_CONFIG_INVALID
+	}
+	n.mu.Lock()
+	if !n.started {
+		n.mu.Unlock()
+		return MOSS_ERR_NOT_STARTED
+	}
+	n.explicitTargets[peerID] = time.Now()
+	n.mu.Unlock()
+	go n.dialExplicitTarget(peerID)
+	return MOSS_OK
+}
+
+// dialExplicitTargets retries registered targets from the peer-maintenance
+// tick, reusing the discovery cooldown so a target is attempted at most once
+// per handshake window.
+func (n *Node) dialExplicitTargets() {
+	now := time.Now()
+	cooldown := n.config.HandshakeTimeout()
+	if cooldown < n.config.Heartbeat() {
+		cooldown = n.config.Heartbeat()
+	}
+	if cooldown <= 0 {
+		cooldown = time.Second
+	}
+	n.mu.Lock()
+	due := make([]string, 0, len(n.explicitTargets))
+	for peerID, lastDial := range n.explicitTargets {
+		if _, connected := n.peers[peerID]; connected {
+			continue
+		}
+		if now.Sub(lastDial) < cooldown {
+			continue
+		}
+		n.explicitTargets[peerID] = now
+		due = append(due, peerID)
+	}
+	n.mu.Unlock()
+	for _, peerID := range due {
+		go n.dialExplicitTarget(peerID)
+	}
+}
+
+// dialExplicitTarget runs one connection attempt: the same direct → relay
+// pipeline as dialKnownPeer. A relayed connection is enough — promoteRelayPeers
+// keeps probing it for a direct upgrade.
+func (n *Node) dialExplicitTarget(peerID string) {
+	n.mu.RLock()
+	_, connected := n.peers[peerID]
+	n.mu.RUnlock()
+	if connected {
+		return
+	}
+	if !n.tryDirectConnect(peerID, n.config.HandshakeTimeout()) &&
+		n.establishedRelaySession(peerID) == "" {
+		_, _ = n.OpenRelaySessionAny(peerID, n.config.HandshakeTimeout())
+	}
+}

--- a/internal/mesh/node_lifecycle.go
+++ b/internal/mesh/node_lifecycle.go
@@ -92,6 +92,7 @@ func NewNodeWithIdentity(meshID string, psk []byte, cfg Config, identity *mcrypt
 		relayBuckets:     make(map[string]*nat.TokenBucket),
 		directProbes:     make(map[string]time.Time),
 		peerDials:        make(map[string]time.Time),
+		explicitTargets:  make(map[string]time.Time),
 		bootstrapDials:   make(map[string]time.Time),
 		lanBeaconBuckets: make(map[string]*lanBeaconRateBucket),
 		lanBeaconGlobal:  nat.NewTokenBucket(lanBeaconGlobalBurst, lanBeaconGlobalRate),
@@ -225,6 +226,7 @@ func (n *Node) Stop() int32 {
 		peers = append(peers, peer)
 	}
 	n.peers = make(map[string]*peerConn)
+	n.explicitTargets = make(map[string]time.Time)
 	n.mu.Unlock()
 	cancel()
 	if listener != nil {

--- a/internal/mesh/node_maintenance.go
+++ b/internal/mesh/node_maintenance.go
@@ -263,6 +263,7 @@ func (n *Node) maintenanceLoop(ctx context.Context) {
 			n.pruneLowScoringPeers()
 			n.pruneHighLatencyPeers()
 			n.connectKnownPeers()
+			n.dialExplicitTargets()
 			n.connectBootstrapSeeds(ctx)
 			n.promoteRelayPeers()
 			n.refreshLocalSubscriptions()

--- a/internal/mesh/node_peer_discovery.go
+++ b/internal/mesh/node_peer_discovery.go
@@ -67,14 +67,14 @@ func (n *Node) discoveredPeerTargets() []discoveredPeerTarget {
 		})
 	}
 
+	// Neutral ordering: bootstrap seeds first (they are how the node joins at
+	// all), then score / recency. Relay-capable peers get NO blanket priority —
+	// when every node dials supernodes first the mesh degrades into a star that
+	// funnels the whole network's gossip through them. Relay availability is
+	// covered by the small quota in selectDialTargets instead.
 	sort.Slice(targets, func(i, j int) bool {
 		if targets[i].info.bootstrap != targets[j].info.bootstrap {
 			return targets[i].info.bootstrap
-		}
-		rankI := relayCandidateRank(targets[i].info)
-		rankJ := relayCandidateRank(targets[j].info)
-		if rankI != rankJ {
-			return rankI > rankJ
 		}
 		scoreI := n.peerScore(targets[i].peerID)
 		scoreJ := n.peerScore(targets[j].peerID)
@@ -95,12 +95,59 @@ func (n *Node) discoveredPeerTargets() []discoveredPeerTarget {
 	if available < limit {
 		limit = available
 	}
-	if len(targets) < limit {
-		limit = len(targets)
-	}
-	selected := append([]discoveredPeerTarget(nil), targets[:limit]...)
+	selected := selectDialTargets(targets, limit, relayDialQuota-n.relayCapableConnectedLocked())
 	for _, target := range selected {
 		n.peerDials[target.peerID] = now
+	}
+	return selected
+}
+
+// relayDialQuota is how many relay-capable connections a node keeps alive for
+// the relay fallback path (and relay_ready); beyond it, relay-capable peers
+// are dialed only when no plain candidate is available.
+const relayDialQuota = 2
+
+func (n *Node) relayCapableConnectedLocked() int {
+	count := 0
+	for peerID, peer := range n.peers {
+		if peer == nil || peer.relayed {
+			continue
+		}
+		if n.knownPeers[peerID].relayCapable {
+			count++
+		}
+	}
+	return count
+}
+
+// selectDialTargets takes up to limit targets from the ordered candidate list:
+// bootstrap seeds always, relay-capable peers only while the quota deficit
+// lasts, plain peers freely. Remaining slots fall back to the skipped
+// relay-capable candidates so a relay-heavy neighborhood still fills up.
+func selectDialTargets(targets []discoveredPeerTarget, limit, relayDeficit int) []discoveredPeerTarget {
+	if limit <= 0 {
+		return nil
+	}
+	selected := make([]discoveredPeerTarget, 0, limit)
+	skipped := make([]discoveredPeerTarget, 0)
+	for _, target := range targets {
+		if len(selected) == limit {
+			break
+		}
+		if target.info.relayCapable && !target.info.bootstrap {
+			if relayDeficit <= 0 {
+				skipped = append(skipped, target)
+				continue
+			}
+			relayDeficit--
+		}
+		selected = append(selected, target)
+	}
+	for _, target := range skipped {
+		if len(selected) == limit {
+			break
+		}
+		selected = append(selected, target)
 	}
 	return selected
 }

--- a/internal/mesh/node_peer_discovery.go
+++ b/internal/mesh/node_peer_discovery.go
@@ -120,26 +120,39 @@ func (n *Node) relayCapableConnectedLocked() int {
 	return count
 }
 
-// selectDialTargets takes up to limit targets from the ordered candidate list:
-// bootstrap seeds always, relay-capable peers only while the quota deficit
-// lasts, plain peers freely. Remaining slots fall back to the skipped
-// relay-capable candidates so a relay-heavy neighborhood still fills up.
+// selectDialTargets takes up to limit targets from the ordered candidate list.
+// While the relay quota has a deficit, that many slots are RESERVED for the
+// best relay-capable candidates regardless of where they sort — otherwise a
+// handful of fresher plain peers could starve the relay fallback. The rest of
+// the slots go to bootstrap/plain candidates in ranking order, and leftover
+// relay-capable candidates fill only what remains.
 func selectDialTargets(targets []discoveredPeerTarget, limit, relayDeficit int) []discoveredPeerTarget {
 	if limit <= 0 {
 		return nil
 	}
 	selected := make([]discoveredPeerTarget, 0, limit)
+	taken := make(map[string]bool, limit)
+	for _, target := range targets {
+		if relayDeficit <= 0 || len(selected) == limit {
+			break
+		}
+		if target.info.relayCapable {
+			selected = append(selected, target)
+			taken[target.peerID] = true
+			relayDeficit--
+		}
+	}
 	skipped := make([]discoveredPeerTarget, 0)
 	for _, target := range targets {
 		if len(selected) == limit {
 			break
 		}
+		if taken[target.peerID] {
+			continue
+		}
 		if target.info.relayCapable && !target.info.bootstrap {
-			if relayDeficit <= 0 {
-				skipped = append(skipped, target)
-				continue
-			}
-			relayDeficit--
+			skipped = append(skipped, target)
+			continue
 		}
 		selected = append(selected, target)
 	}

--- a/internal/mesh/node_types.go
+++ b/internal/mesh/node_types.go
@@ -69,6 +69,7 @@ type Node struct {
 	relayBuckets     map[string]*nat.TokenBucket
 	directProbes     map[string]time.Time
 	peerDials        map[string]time.Time
+	explicitTargets  map[string]time.Time
 	bootstrapDials   map[string]time.Time
 	lanBeaconBuckets map[string]*lanBeaconRateBucket
 	lanBeaconGlobal  *nat.TokenBucket

--- a/internal/mesh/peer_discovery_ranking_test.go
+++ b/internal/mesh/peer_discovery_ranking_test.go
@@ -1,0 +1,108 @@
+package mesh
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// rankingTestNode returns an unstarted node whose dial-target selection can be
+// driven purely through injected knownPeers / peers state.
+func rankingTestNode(t *testing.T, dOut int) *Node {
+	t.Helper()
+	cfg := isolatedTestConfig("dial-ranking")
+	cfg.GossipSub.DOut = dOut
+	node, err := NewNode("mesh-dial-ranking", nil, cfg)
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+	return node
+}
+
+func addRankingCandidate(node *Node, id string, relayCapable bool) {
+	node.mu.Lock()
+	node.knownPeers[id] = knownPeer{
+		id:              id,
+		addr:            "203.0.113.10:4001",
+		verified:        true,
+		publicReachable: true,
+		natTrusted:      true,
+		relayCapable:    relayCapable,
+		lastSeen:        time.Now(),
+	}
+	node.mu.Unlock()
+}
+
+func addConnectedRelayCapable(node *Node, id string) {
+	addRankingCandidate(node, id, true)
+	node.mu.Lock()
+	node.peers[id] = &peerConn{id: id, addr: "203.0.113.9:4001"}
+	node.mu.Unlock()
+}
+
+func selectedIDs(node *Node) map[string]bool {
+	ids := make(map[string]bool)
+	for _, target := range node.discoveredPeerTargets() {
+		ids[target.peerID] = true
+	}
+	return ids
+}
+
+// With the relay quota already met by connected peers, dial targets must not
+// prefer relay-capable peers: every node clustering on supernodes turns the
+// mesh into a star and concentrates the whole network's gossip on them.
+func TestDialTargetsSkipRelayCapableWhenQuotaMet(t *testing.T) {
+	node := rankingTestNode(t, 3)
+	addConnectedRelayCapable(node, "aa"+fmt.Sprintf("%062d", 1))
+	addConnectedRelayCapable(node, "aa"+fmt.Sprintf("%062d", 2))
+
+	plain := []string{}
+	for i := 0; i < 3; i++ {
+		id := "cc" + fmt.Sprintf("%062d", i)
+		plain = append(plain, id)
+		addRankingCandidate(node, id, false)
+	}
+	for i := 0; i < 3; i++ {
+		addRankingCandidate(node, "bb"+fmt.Sprintf("%062d", i), true)
+	}
+
+	selected := selectedIDs(node)
+	for _, id := range plain {
+		if !selected[id] {
+			t.Fatalf("plain peer %s not selected; selected=%v", id, selected)
+		}
+	}
+	for id := range selected {
+		if id[:2] == "bb" {
+			t.Fatalf("relay-capable peer %s selected while quota is met and plain peers exist", id)
+		}
+	}
+}
+
+// With no relay-capable peer connected, the deficit (quota of 2) is filled
+// with relay-capable candidates first — relay fallback and relay_ready need
+// at least a couple of them — but never more than the deficit while plain
+// candidates remain.
+func TestDialTargetsFillRelayQuotaDeficitOnly(t *testing.T) {
+	node := rankingTestNode(t, 4)
+	for i := 0; i < 3; i++ {
+		addRankingCandidate(node, "bb"+fmt.Sprintf("%062d", i), true)
+	}
+	for i := 0; i < 3; i++ {
+		addRankingCandidate(node, "cc"+fmt.Sprintf("%062d", i), false)
+	}
+
+	selected := selectedIDs(node)
+	relayCount := 0
+	for id := range selected {
+		if id[:2] == "bb" {
+			relayCount++
+		}
+	}
+	if relayCount != 2 {
+		t.Fatalf("expected exactly 2 relay-capable targets (the quota deficit), got %d; selected=%v", relayCount, selected)
+	}
+	if len(selected) != 4 {
+		t.Fatalf("expected DOut=4 targets, got %d: %v", len(selected), selected)
+	}
+}


### PR DESCRIPTION
## Why

The shared-substrate change made rooms pub/sub-only and room-blind, which removed the one mechanism a DM relied on to reach its counterpart:

- discovery is keyed by NetworkID, so a DM counterpart is 1 of N world peers the ranking may never select;
- the glare rule forbids the higher-id public node from dialing a public peer at all;
- pub/sub only delivers between connected subscribers, so two room members that never connect share a dead room.

Result: mosh DMs stuck on `relayed via supernode`, never `direct` (mosh v0.6.4 + moss v0.6.12).

## What

1. **`ConnectToPeer(peerID)`** (+ `Moss_ConnectToPeer` FFI export) — registers a persistent explicit target: dialed immediately, retried from the peer-maintenance tick (direct first, relay fallback), bypassing glare and dial ranking. `promoteRelayPeers` upgrades the relayed leg to direct as before.
2. **Neutral dial ranking** — `discoveredPeerTargets` no longer puts `relayCandidateRank` above score: supernode-first dialing was collapsing the mesh into a star and funneling all gossip through relay infrastructure. Relay-capable peers are kept to a quota of 2 connections (relay fallback + `relay_ready`), used beyond that only when no plain candidate remains. `selectRelayPeers` keeps its relay-capable preference — there it is the point.

## Tests

- `explicit_target_test.go`: glare-bypass connect (higher-id dials lower-id), retry-until-announced, input validation.
- `peer_discovery_ranking_test.go`: quota-met exclusion, deficit-only fill.
- Full `./internal/mesh` suite: 182 pass.
