### PR TITLE
fix(transport): let bind_interface reach the sockets that ignored it

### DIFF
--- a/internal/mesh/dht.go
+++ b/internal/mesh/dht.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/redstone-md/moss/internal/transport"
+
 	dht "github.com/anacrolix/dht/v2"
 )
 
@@ -24,9 +26,20 @@ type dhtSource struct {
 // discoverable and keeps finding peers that come online later. onPeers is
 // called with "ip:port" strings as peers arrive. Best-effort; the mesh does
 // not depend on it.
-func startDHTSource(infoHash [20]byte, dhtPort int, interval time.Duration, announcePort func() int, onPeers func([]string)) (*dhtSource, error) {
+//
+// bindIfIndex pins the socket to one NIC. It must match the mesh listener's:
+// the DHT announces whatever address this socket's traffic appears to come
+// from, so an unbound DHT under a VPN publishes the tunnel's exit while the
+// mesh publishes the physical WAN, and peers get two contradictory answers for
+// one node. A bind failure kills the DHT rather than letting it announce the
+// wrong address — best-effort means optional, not "any address will do".
+func startDHTSource(infoHash [20]byte, dhtPort int, bindIfIndex int, interval time.Duration, announcePort func() int, onPeers func([]string)) (*dhtSource, error) {
 	conn, err := net.ListenPacket("udp", ":"+strconv.Itoa(dhtPort))
 	if err != nil {
+		return nil, err
+	}
+	if err := transport.ApplyBindToPacket(conn, bindIfIndex); err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 	cfg := dht.NewDefaultServerConfig()

--- a/internal/mesh/dht_test.go
+++ b/internal/mesh/dht_test.go
@@ -8,7 +8,7 @@ import (
 func TestDHTSourceStartStop(t *testing.T) {
 	var ih [20]byte
 	copy(ih[:], []byte("moss-dht-test-hash--"))
-	src, err := startDHTSource(ih, 0, time.Minute, func() int { return 41010 }, func(addrs []string) { _ = addrs })
+	src, err := startDHTSource(ih, 0, 0, time.Minute, func() int { return 41010 }, func(addrs []string) { _ = addrs })
 	if err != nil {
 		t.Fatalf("start dht: %v", err)
 	}

--- a/internal/mesh/node_accept.go
+++ b/internal/mesh/node_accept.go
@@ -227,7 +227,11 @@ func (n *Node) connectPeerTCPWithHint(ctx context.Context, addr, peerID string) 
 }
 
 func (n *Node) connectPeerOnce(ctx context.Context, addr string, remoteStatic []byte) error {
-	dialer := &net.Dialer{Timeout: n.config.HandshakeTimeout()}
+	// Bound to the same NIC as the UDP listener: an outbound dial left to the
+	// routing table leaves through the VPN, so the peer observes us at the
+	// tunnel's exit and echoes that back as our address — which is how one node
+	// ends up advertising two of them.
+	dialer := transport.DialerWithBind(net.Dialer{Timeout: n.config.HandshakeTimeout()}, n.bindIfIndex)
 	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return err

--- a/internal/mesh/node_lifecycle.go
+++ b/internal/mesh/node_lifecycle.go
@@ -210,7 +210,7 @@ func (n *Node) Start() int32 {
 		n.wg.Add(1)
 		go func() {
 			defer n.wg.Done()
-			src, err := startDHTSource(n.infoHash, n.config.DHTPort, n.config.AnnounceInterval(), n.announcePort, func(addrs []string) {
+			src, err := startDHTSource(n.infoHash, n.config.DHTPort, n.bindIfIndex, n.config.AnnounceInterval(), n.announcePort, func(addrs []string) {
 				n.rememberTrackerSeeds(addrs)
 				n.kickBootstrapPeers(ctx, addrs)
 			})

--- a/internal/mesh/node_nat_control.go
+++ b/internal/mesh/node_nat_control.go
@@ -49,7 +49,7 @@ func (n *Node) handleReachabilityRequest(peer *peerConn, env gossip.Envelope) {
 	if peer == nil || !sameAdvertisedEndpoint(env.AdvertisedAddr, peer.addr) {
 		return
 	}
-	reachable := probeTCPAddress(env.AdvertisedAddr, minDuration(500*time.Millisecond, n.config.HandshakeTimeout()))
+	reachable := probeTCPAddress(env.AdvertisedAddr, minDuration(500*time.Millisecond, n.config.HandshakeTimeout()), n.bindIfIndex)
 	n.sendEnvelope(peer, gossip.Envelope{
 		Type:      gossip.TypeReachabilityResponse,
 		RequestID: env.RequestID,

--- a/internal/mesh/node_network_probe.go
+++ b/internal/mesh/node_network_probe.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/redstone-md/moss/internal/gossip"
 	"github.com/redstone-md/moss/internal/nat"
+	"github.com/redstone-md/moss/internal/transport"
 )
 
 func (n *Node) probePortMapping(ctx context.Context, listenAddr string, port int) {
@@ -80,11 +81,16 @@ func requiresReachabilityConfirmation(addr string) bool {
 	return parsed.IsGlobalUnicast() && !parsed.IsPrivate() && !isCarrierGradeAddr(parsed)
 }
 
-func probeTCPAddress(addr string, timeout time.Duration) bool {
+// probeTCPAddress answers a peer's "can you reach me here?" by dialling the
+// address it claims. bindIfIndex keeps that dial on the NIC the mesh actually
+// uses: a probe that leaves through a VPN reports on a path our own traffic
+// will never take, so the peer would be told it is reachable when it is not.
+func probeTCPAddress(addr string, timeout time.Duration, bindIfIndex int) bool {
 	if timeout <= 0 {
 		timeout = 250 * time.Millisecond
 	}
-	conn, err := net.DialTimeout("tcp", addr, timeout)
+	dialer := transport.DialerWithBind(net.Dialer{Timeout: timeout}, bindIfIndex)
+	conn, err := dialer.Dial("tcp", addr)
 	if err != nil {
 		return false
 	}

--- a/internal/transport/bind.go
+++ b/internal/transport/bind.go
@@ -55,9 +55,10 @@ func ApplyBindToUDP(conn *net.UDPConn, ifIndex int) error {
 	return applyBindInterface(rc, ifIndex)
 }
 
-// applyBindToPacket applies the interface bind to a freshly-created
-// net.PacketConn (used by LAN discovery's net.ListenPacket call sites).
-func applyBindToPacket(conn net.PacketConn, ifIndex int) error {
+// ApplyBindToPacket applies the interface bind to a freshly-created
+// net.PacketConn, for call sites that reach for net.ListenPacket rather than
+// net.ListenUDP (the DHT socket, whose conn is handed to a third-party server).
+func ApplyBindToPacket(conn net.PacketConn, ifIndex int) error {
 	if ifIndex == 0 {
 		return nil
 	}
@@ -72,7 +73,7 @@ func applyBindToPacket(conn net.PacketConn, ifIndex int) error {
 // pinned to the named interface index via the OS-specific helper. A zero
 // ifIndex yields an unmodified Dialer with no Control hook.
 //
-// Use this for net.Dial-flavoured call sites — UDP trackers, NAT-PMP probes,
+// Use this for net.Dial-flavoured call sites — UDP trackers, peer TCP dials,
 // any callers that need outbound traffic to skip the routing table.
 func DialerWithBind(base net.Dialer, ifIndex int) *net.Dialer {
 	if ifIndex == 0 {

--- a/internal/transport/bind_coverage_test.go
+++ b/internal/transport/bind_coverage_test.go
@@ -1,0 +1,84 @@
+package transport
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// rawSocketCall matches the socket constructors that pick their local address
+// from the routing table unless something binds them afterwards.
+var rawSocketCall = regexp.MustCompile(`net\.(Dial|DialTimeout|DialUDP|DialTCP|ListenPacket|Listen|ListenUDP)\(|net\.Dialer\{`)
+
+// alreadyBound matches the helpers that pin a socket to bindIfIndex. A line
+// that hands its socket to one of these is doing the right thing, however raw
+// the constructor next to it looks.
+var alreadyBound = regexp.MustCompile(`DialerWithBind|ApplyBindTo(UDP|Packet)`)
+
+// boundElsewhere lists the files allowed to construct a socket without an
+// immediately visible bind, each for a reason that has to stay true.
+var boundElsewhere = map[string]string{
+	// This file is the bind.
+	filepath.Join("transport", "bind.go"): "applies the bind",
+	// The mesh UDP listener is bound a few lines below, via ApplyBindToUDP.
+	filepath.Join("transport", "udp.go"): "binds the listener it creates",
+	// Inbound TCP stays on 0.0.0.0 on purpose: SO_BINDTODEVICE on a listening
+	// socket would refuse connections arriving over the tunnel, and outbound
+	// TCP gets its own bound dialer in mesh/node_accept.go.
+	filepath.Join("transport", "listener.go"): "inbound only, deliberately unbound",
+	// Send socket is bound at the call site; the receive socket joins a
+	// link-local multicast group per interface and never leaves the LAN.
+	filepath.Join("mesh", "lan_discovery.go"): "binds its send socket, receive is link-local",
+	// Bound immediately after ListenPacket.
+	filepath.Join("mesh", "dht.go"): "binds the socket it creates",
+	// PCP/NAT-PMP talks to on-link gateways over their own chain, which does
+	// not carry bindIfIndex yet. Tracked separately; a mapping obtained from a
+	// VPN gateway is the remaining way to advertise a tunnel-side address.
+	filepath.Join("nat", "pmp.go"): "on-link gateway, separate plumbing",
+}
+
+// TestNoUnboundSocketCallSites fails when a new socket appears somewhere that
+// cannot honour bind_interface. Splitting the node across two NICs is invisible
+// at runtime — it shows up as a peer advertising two addresses and the mesh
+// arguing about which is real — so the invariant is guarded at the source.
+func TestNoUnboundSocketCallSites(t *testing.T) {
+	root := ".."
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if _, ok := boundElsewhere[rel]; ok {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") || alreadyBound.MatchString(line) {
+				continue
+			}
+			if rawSocketCall.MatchString(line) {
+				t.Errorf("%s:%d creates a socket the routing table controls:\n\t%s\n"+
+					"use transport.DialerWithBind / ApplyBindToUDP / ApplyBindToPacket with the node's "+
+					"bindIfIndex, or add the file to boundElsewhere with the reason it is exempt",
+					rel, i+1, strings.TrimSpace(line))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk internal/: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

`bind_interface` bound the mesh UDP listener, tracker HTTP/UDP and LAN discovery. It did not bind the DHT socket, peer TCP dials, the TCP listener or the reachability probe.

Under a VPN that splits the node in two: bound sockets speak from the physical WAN, unbound ones leave through the tunnel. The node then advertises two external addresses and its peers disagree about which is real. On a live session with a bypass configured, `in_prune` hit **12,940 in three minutes**; with the bypass off it was **138**.

## What

`bindIfIndex` now reaches the three sockets that decide what address the outside world sees:

| Socket | Why it matters |
|---|---|
| DHT (`mesh/dht.go`) | announces whatever address its traffic appears to come from |
| peer TCP dial (`mesh/node_accept.go`) | the peer echoes our observed source back as our address |
| reachability probe (`mesh/node_network_probe.go`) | answers "can you reach me here?" — must answer for the path the mesh uses |

**The inbound TCP listener is deliberately left on `0.0.0.0`.** `SO_BINDTODEVICE` on a listening socket would refuse connections arriving over the tunnel, and on Windows `IP_UNICAST_IF` on a listener does nothing. Outbound TCP is covered by the bound dialer instead. The UDP listener is the opposite case and keeps its bind: one socket serves every destination, so it alone picks the source address.

DHT bind failure kills the DHT rather than letting it announce the wrong address — best-effort means optional, not "any address will do".

## Guard

`TestNoUnboundSocketCallSites` walks `internal/` and fails when a socket is constructed somewhere that cannot honour the bind, with a small allowlist that carries a reason per entry. Verified it fires: dropping one allowlist entry produces `mesh\dht.go:37 creates a socket the routing table controls`.

The failure mode is invisible at runtime — it shows up days later as a peer with two addresses — so the invariant is checked where it is written.

## Not covered

PCP/NAT-PMP (`internal/nat/pmp.go`) talks to on-link gateways over its own plumbing and is allowlisted. A mapping granted by a VPN gateway is the remaining way to advertise a tunnel-side address.

## Test

`go build ./...` clean, `go vet` clean, `go test ./... -count=1` → **398 passed in 17 packages**.