### PR TITLE
fix(gossip): stop a mesh full of strangers from suppressing discovery

### DIFF
--- a/internal/gossip/confirmed_mesh_test.go
+++ b/internal/gossip/confirmed_mesh_test.go
@@ -1,0 +1,51 @@
+package gossip
+
+import "testing"
+
+// A graft marks its target in-mesh before the target has answered. If that
+// counts as membership, a node that has no idea who is on a channel fills its
+// mesh with strangers and reports it full — which is what suppressed topic
+// discovery on every maintenance pass and left two-party channels undeliverable
+// while the connection itself was fine.
+func TestConfirmedMeshPeersIgnoresUnanswered(t *testing.T) {
+	m := NewManager()
+	m.Subscribe("dm-session")
+
+	// Six peers grafted on spec: in the mesh, none of them has claimed it.
+	for _, id := range []string{"p1", "p2", "p3", "p4", "p5", "p6"} {
+		m.SetMeshPeer("dm-session", id, true)
+	}
+	if got := len(m.MeshPeers("dm-session")); got != 6 {
+		t.Fatalf("mesh holds %d, want 6 — the optimistic marks are real", got)
+	}
+	if got := m.ConfirmedMeshPeers("dm-session"); got != 0 {
+		t.Fatalf("confirmed = %d, want 0 — nobody answered yet", got)
+	}
+
+	// The counterpart grafts us back: now one member is real.
+	m.SetPeerSubscription("p3", "dm-session", true)
+	if got := m.ConfirmedMeshPeers("dm-session"); got != 1 {
+		t.Fatalf("confirmed = %d, want 1", got)
+	}
+
+	// A subscriber outside the mesh is not a mesh member.
+	m.SetPeerSubscription("outsider", "dm-session", true)
+	if got := m.ConfirmedMeshPeers("dm-session"); got != 1 {
+		t.Fatalf("confirmed = %d, want 1 — a non-mesh subscriber does not count", got)
+	}
+
+	// PRUNE: the strangers drop out, the confirmed one stays.
+	for _, id := range []string{"p1", "p2", "p4", "p5", "p6"} {
+		m.SetMeshPeer("dm-session", id, false)
+	}
+	if got := m.ConfirmedMeshPeers("dm-session"); got != 1 {
+		t.Fatalf("confirmed = %d after pruning strangers, want 1", got)
+	}
+}
+
+func TestConfirmedMeshPeersOnAnEmptyChannel(t *testing.T) {
+	m := NewManager()
+	if got := m.ConfirmedMeshPeers("never-seen"); got != 0 {
+		t.Fatalf("confirmed = %d, want 0", got)
+	}
+}

--- a/internal/gossip/pubsub.go
+++ b/internal/gossip/pubsub.go
@@ -141,6 +141,27 @@ func (m *Manager) NonMeshSubscribers(channel string) []string {
 	return out
 }
 
+// ConfirmedMeshPeers counts mesh members that have themselves claimed the
+// channel, as opposed to ones grafted on spec and not yet answered.
+//
+// The distinction decides whether a topic still needs to be discovered. A graft
+// marks its target as a mesh peer before the target has said anything, so a
+// node with no idea who is on a channel can fill its mesh with strangers and
+// look healthy for as long as it takes them to answer PRUNE — every time, on
+// every maintenance pass. Counting only confirmed members keeps "the mesh is
+// full" from meaning "we asked six people at random".
+func (m *Manager) ConfirmedMeshPeers(channel string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	count := 0
+	for peerID := range m.meshPeers[channel] {
+		if _, ok := m.peerSubscriptions[peerID][channel]; ok {
+			count++
+		}
+	}
+	return count
+}
+
 func (m *Manager) InMesh(channel, peerID string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/mesh/node_integration_overlay_test.go
+++ b/internal/mesh/node_integration_overlay_test.go
@@ -94,8 +94,8 @@ func TestOverlayLeavesFindEachOtherThroughCore(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	a.republishOverlayRecords(ctx)
-	b.republishOverlayRecords(ctx)
+	a.republishOverlayRecords(ctx, overlaySeedTally{})
+	b.republishOverlayRecords(ctx, overlaySeedTally{})
 
 	topic := a.roomTopic("sparse-channel")
 	var found map[string]reachabilityHint
@@ -163,8 +163,8 @@ func TestOverlayDeliversBetweenLeavesWithNoDirectPath(t *testing.T) {
 	// the test does not wait on it. Everything after this is the mesh's own doing.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	a.republishOverlayRecords(ctx)
-	b.republishOverlayRecords(ctx)
+	a.republishOverlayRecords(ctx, overlaySeedTally{})
+	b.republishOverlayRecords(ctx, overlaySeedTally{})
 
 	deadline := time.Now().Add(25 * time.Second)
 	for time.Now().Before(deadline) {
@@ -207,7 +207,7 @@ func TestOverlayStoreAttributesToSender(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	leaf.republishOverlayRecords(ctx)
+	leaf.republishOverlayRecords(ctx, overlaySeedTally{})
 
 	self, ok := leaf.localOverlayID()
 	if !ok {

--- a/internal/mesh/node_overlay.go
+++ b/internal/mesh/node_overlay.go
@@ -620,7 +620,15 @@ const overlayTopicDiscoveryEvery = 15 * time.Second
 //
 // It never blocks the caller: maintainTopicMesh runs on the maintenance tick.
 func (n *Node) maybeDiscoverTopicPeers(topic string) {
-	if len(n.pubsub.MeshPeers(topic)) >= n.config.GossipSub.DLo {
+	// Confirmed members only. ensureTopicMeshMinimum runs earlier in the same
+	// maintenance pass and, with nobody known to be on the topic, grafts up to D
+	// peers picked at random and marks them in-mesh before any of them answers.
+	// Counting those made the mesh look full on every pass, so this returned
+	// every time and the rendezvous that would find the actual subscriber never
+	// ran. They then answer PRUNE — they are not on the topic — the mesh empties,
+	// and the next pass repeats it. A two-party channel could sit in that loop
+	// forever with a healthy connection and nothing ever delivered.
+	if n.pubsub.ConfirmedMeshPeers(topic) >= n.config.GossipSub.DLo {
 		return
 	}
 	if len(n.pubsub.NonMeshSubscribers(topic)) > 0 {

--- a/internal/mesh/node_overlay.go
+++ b/internal/mesh/node_overlay.go
@@ -2,10 +2,10 @@ package mesh
 
 import (
 	"context"
-	"sync"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/redstone-md/moss/internal/gossip"
@@ -54,38 +54,77 @@ func (n *Node) localOverlayID() (overlay.NodeID, bool) {
 	return overlay.IDFromHex(n.localPeerID())
 }
 
+// overlaySeedTally counts why a seed pass did or did not grow the routing
+// table. A client whose table stays empty cannot publish records or resolve a
+// rendezvous, and every symptom above that — a topic mesh that never holds the
+// counterpart, a handshake that never arrives — reads the same as "nobody is
+// there". The counts say which gate is closing.
+type overlaySeedTally struct {
+	considered   int
+	added        int
+	notReachable int
+	noAddr       int
+	badID        int
+	noTable      int
+}
+
 // noteOverlayContact records a peer as a routable contact when it is publicly
 // reachable. Only such peers belong in the table — a contact that cannot be
-// dialed is useless as a lookup hop.
-func (n *Node) noteOverlayContact(info knownPeer) {
-	if !info.publicReachable || info.addr == "" {
+// dialed is useless as a lookup hop. It reports which gate rejected the peer so
+// the seed pass can tally; per-call logging would be a firehose, since this
+// walks every known peer twice a minute.
+func (n *Node) noteOverlayContact(info knownPeer, tally *overlaySeedTally) {
+	if tally != nil {
+		tally.considered++
+	}
+	if !info.publicReachable {
+		if tally != nil {
+			tally.notReachable++
+		}
+		return
+	}
+	if info.addr == "" {
+		if tally != nil {
+			tally.noAddr++
+		}
 		return
 	}
 	cid, ok := overlay.IDFromHex(info.id)
 	if !ok {
+		if tally != nil {
+			tally.badID++
+		}
 		return
 	}
 	if n.overlayTable == nil {
+		if tally != nil {
+			tally.noTable++
+		}
 		return
 	}
 	// The table guards itself; taking the node's lock here would put discovery
 	// traffic in the way of everything else the node does.
 	n.overlayTable.Add(overlay.Contact{ID: cid, Addr: info.addr, LastSeen: time.Now()})
+	if tally != nil {
+		tally.added++
+	}
 }
 
 // overlaySeedFromKnownPeers refills the routing table from what the substrate
 // already gossips. The peer-exchange layer learns reachable peers anyway; the
 // overlay only needs them organised by distance.
-func (n *Node) overlaySeedFromKnownPeers() {
+func (n *Node) overlaySeedFromKnownPeers() overlaySeedTally {
 	n.mu.RLock()
 	infos := make([]knownPeer, 0, len(n.knownPeers))
 	for _, info := range n.knownPeers {
 		infos = append(infos, info)
 	}
 	n.mu.RUnlock()
+	var tally overlaySeedTally
 	for _, info := range infos {
-		n.noteOverlayContact(info)
+		n.noteOverlayContact(info, &tally)
 	}
+	return tally
 }
 
 // ---- core side: answering queries ----
@@ -523,8 +562,7 @@ func (n *Node) overlayPublishLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			n.overlaySeedFromKnownPeers()
-			n.republishOverlayRecords(ctx)
+			n.republishOverlayRecords(ctx, n.overlaySeedFromKnownPeers())
 			n.mu.RLock()
 			store := n.overlayStore
 			n.mu.RUnlock()
@@ -538,7 +576,7 @@ func (n *Node) overlayPublishLoop(ctx context.Context) {
 // republishOverlayRecords refreshes our records and reports how many nodes
 // accepted them. The count is the layer's only honest health signal: a lookup
 // cannot tell "nobody is on this channel" from "nothing was ever stored".
-func (n *Node) republishOverlayRecords(ctx context.Context) int {
+func (n *Node) republishOverlayRecords(ctx context.Context, seed overlaySeedTally) int {
 	self, ok := n.localOverlayID()
 	if !ok {
 		return 0
@@ -560,7 +598,7 @@ func (n *Node) republishOverlayRecords(ctx context.Context) int {
 		}
 		stored += n.overlayPublish(pubCtx, overlay.ChannelKey(topic), hint)
 	}
-	n.reportOverlayPublish(stored, len(topics), started)
+	n.reportOverlayPublish(stored, len(topics), started, seed)
 	return stored
 }
 

--- a/internal/mesh/node_overlay.go
+++ b/internal/mesh/node_overlay.go
@@ -592,13 +592,16 @@ func (n *Node) republishOverlayRecords(ctx context.Context, seed overlaySeedTall
 	// two nodes in the same room derive the same key while a core node holding
 	// the record still cannot tell which room or game it belongs to.
 	topics := n.pubsub.SnapshotLocal()
+	topicKeys := make([]string, 0, len(topics))
 	for _, topic := range topics {
 		if pubCtx.Err() != nil {
 			break
 		}
-		stored += n.overlayPublish(pubCtx, overlay.ChannelKey(topic), hint)
+		key := overlay.ChannelKey(topic)
+		topicKeys = append(topicKeys, key.String()[:16])
+		stored += n.overlayPublish(pubCtx, key, hint)
 	}
-	n.reportOverlayPublish(stored, len(topics), started, seed)
+	n.reportOverlayPublish(stored, len(topics), topicKeys, started, seed)
 	return stored
 }
 
@@ -661,11 +664,14 @@ func (n *Node) maybeDiscoverTopicPeers(topic string) {
 // be grafted.
 func (n *Node) discoverTopicPeers(ctx context.Context, topic string) {
 	started := time.Now()
+	// The same derivation the publish side uses, reported alongside the result
+	// so a lookup and a store can be compared rather than assumed to agree.
+	topicKey := overlay.ChannelKey(topic).String()[:16]
 	lookupCtx, cancel := withTimeout(ctx, 20*time.Second)
 	defer cancel()
 	found := n.findChannelPeers(lookupCtx, topic)
 	if len(found) == 0 {
-		n.reportRendezvous(0, 0, started)
+		n.reportRendezvous(0, 0, topicKey, started)
 		return
 	}
 	reached := 0
@@ -685,7 +691,7 @@ func (n *Node) discoverTopicPeers(ctx context.Context, topic string) {
 			n.reportConnectAttempt(outcomeFailed, reasonUnreachablePex, attemptAt, true)
 		}
 	}
-	n.reportRendezvous(len(found), reached, started)
+	n.reportRendezvous(len(found), reached, topicKey, started)
 	if reached > 0 {
 		n.maintainTopicMesh(topic)
 	}

--- a/internal/mesh/node_peer_announce.go
+++ b/internal/mesh/node_peer_announce.go
@@ -280,6 +280,7 @@ func (n *Node) handleKnownPeerEnvelope(peer *peerConn, env gossip.Envelope, forw
 	}
 	trustCapabilities := verifySupernodeStatusEnvelope(env)
 	changed := false
+	var learned knownPeer
 	n.mu.Lock()
 	current, ok := n.knownPeers[env.AdvertisedPeerID]
 	addr := preferredKnownPeerAddr(current, env.AdvertisedAddr)
@@ -323,7 +324,7 @@ func (n *Node) handleKnownPeerEnvelope(peer *peerConn, env gossip.Envelope, forw
 		if peer != nil && peer.outbound && env.AdvertisedPeerID == peer.id && peer.bootstrap {
 			bootstrap = true
 		}
-		n.knownPeers[env.AdvertisedPeerID] = knownPeer{
+		learned = knownPeer{
 			id:                     env.AdvertisedPeerID,
 			addr:                   addr,
 			direct:                 direct,
@@ -341,9 +342,20 @@ func (n *Node) handleKnownPeerEnvelope(peer *peerConn, env gossip.Envelope, forw
 			signature:              signature,
 			thirdPartyDialable:     thirdPartyDialable,
 		}
+		n.knownPeers[env.AdvertisedPeerID] = learned
 		changed = true
 	}
 	n.mu.Unlock()
+	// Offer the peer to the overlay the moment we learn it is routable, rather
+	// than waiting for the 30s republish pass that used to be the only thing
+	// that filled the table. A DM subscribes and looks for its counterpart
+	// within seconds of the node starting, so every lookup in that first window
+	// queried an empty table and could only return nothing — while the peers it
+	// needed were already known. The table guards itself, so this stays outside
+	// the node lock.
+	if changed {
+		n.noteOverlayContact(learned, nil)
+	}
 	// Re-flood a peer announcement only on a MEANINGFUL change — a new peer, or
 	// a change in capability / reachability / NAT type / identity / IP. A bare
 	// port flip (symmetric-NAT and ephemeral-egress peers churn their source

--- a/internal/mesh/node_telemetry_nat.go
+++ b/internal/mesh/node_telemetry_nat.go
@@ -223,7 +223,7 @@ func (n *Node) reportRendezvous(found, reached int, started time.Time) {
 // invisible while it made every rendezvous on the network fail. The count of
 // nodes that accepted a STORE is the difference between "the layer works and the
 // room is empty" and "the layer has never once worked".
-func (n *Node) reportOverlayPublish(stored, topics int, started time.Time) {
+func (n *Node) reportOverlayPublish(stored, topics int, started time.Time, seed overlaySeedTally) {
 	if n.axiom.Load() == nil {
 		return
 	}
@@ -235,6 +235,16 @@ func (n *Node) reportOverlayPublish(stored, topics int, started time.Time) {
 	if n.overlayTable != nil {
 		fields["contacts"] = n.overlayTable.Len()
 	}
+	// The seed pass that just ran, broken down by which gate closed. An empty
+	// table is the difference between "the overlay is idle" and "the overlay
+	// was never able to start", and these say which peer property is missing
+	// rather than leaving it to be guessed at from the outside.
+	fields["seed_considered"] = seed.considered
+	fields["seed_added"] = seed.added
+	fields["seed_rej_unreachable"] = seed.notReachable
+	fields["seed_rej_no_addr"] = seed.noAddr
+	fields["seed_rej_bad_id"] = seed.badID
+	fields["seed_rej_no_table"] = seed.noTable
 	level := "info"
 	if stored == 0 {
 		level = "warn"

--- a/internal/mesh/node_telemetry_nat.go
+++ b/internal/mesh/node_telemetry_nat.go
@@ -3,6 +3,7 @@ package mesh
 import (
 	"net"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -194,7 +195,7 @@ func (n *Node) reportConnectAttempt(outcome, reason string, started time.Time, v
 // resolved and how many became reachable. A lookup that finds peers but reaches
 // none says the rendezvous works and the path does not — the two failures are
 // worth telling apart, and nothing else in the system distinguishes them.
-func (n *Node) reportRendezvous(found, reached int, started time.Time) {
+func (n *Node) reportRendezvous(found, reached int, topicKey string, started time.Time) {
 	if n.axiom.Load() == nil {
 		return
 	}
@@ -202,6 +203,11 @@ func (n *Node) reportRendezvous(found, reached int, started time.Time) {
 	fields["found"] = found
 	fields["reached"] = reached
 	fields["took_ms"] = time.Since(started).Milliseconds()
+	// The key this lookup asked about. found=0 cannot distinguish "nobody is on
+	// the channel" from "we asked about a key nothing was ever stored under",
+	// and the publish side reports the same value, so the two can be compared
+	// instead of assumed equal.
+	fields["topic_key"] = topicKey
 	// The routing table's size is the difference between "nobody is on this
 	// channel" and "we had nobody to ask" — found=0 reads identically either
 	// way, and publishing needs the same table a lookup does, so an empty one
@@ -223,7 +229,7 @@ func (n *Node) reportRendezvous(found, reached int, started time.Time) {
 // invisible while it made every rendezvous on the network fail. The count of
 // nodes that accepted a STORE is the difference between "the layer works and the
 // room is empty" and "the layer has never once worked".
-func (n *Node) reportOverlayPublish(stored, topics int, started time.Time, seed overlaySeedTally) {
+func (n *Node) reportOverlayPublish(stored, topics int, topicKeys []string, started time.Time, seed overlaySeedTally) {
 	if n.axiom.Load() == nil {
 		return
 	}
@@ -245,6 +251,11 @@ func (n *Node) reportOverlayPublish(stored, topics int, started time.Time, seed 
 	fields["seed_rej_no_addr"] = seed.noAddr
 	fields["seed_rej_bad_id"] = seed.badID
 	fields["seed_rej_no_table"] = seed.noTable
+	// The keys these records were stored under. A rendezvous reports the key it
+	// asked about, so the two sides can be lined up: a lookup that finds nothing
+	// under a key nobody stored is a different bug from one that finds nothing
+	// under the right key.
+	fields["topic_keys"] = strings.Join(topicKeys, ",")
 	level := "info"
 	if stored == 0 {
 		level = "warn"

--- a/internal/mesh/node_telemetry_nat_test.go
+++ b/internal/mesh/node_telemetry_nat_test.go
@@ -101,6 +101,6 @@ func TestReportingIsANoopWithoutASink(t *testing.T) {
 	}
 	// Must not panic or block.
 	n.reportConnectAttempt(outcomeDirect, reasonNone, time.Now(), false)
-	n.reportRendezvous(1, 0, time.Now())
+	n.reportRendezvous(1, 0, "deadbeefdeadbeef", time.Now())
 	n.reportSessionLifetime(false, time.Now(), 0, originDialTCP, "tcp", 0, "abc123")
 }

--- a/internal/mesh/overlay_lookup_reach_test.go
+++ b/internal/mesh/overlay_lookup_reach_test.go
@@ -75,7 +75,7 @@ func TestLookupReachesPastUnreachableNearestContacts(t *testing.T) {
 	defer cancel()
 
 	// A's record lands on the core it shares with B.
-	if stored := a.republishOverlayRecords(ctx); stored == 0 {
+	if stored := a.republishOverlayRecords(ctx, overlaySeedTally{}); stored == 0 {
 		t.Fatal("A stored its record nowhere: a record nobody holds can never be found")
 	}
 
@@ -141,7 +141,7 @@ func TestPublishReportsWhereItLanded(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
-	if stored := a.republishOverlayRecords(ctx); stored == 0 {
+	if stored := a.republishOverlayRecords(ctx, overlaySeedTally{}); stored == 0 {
 		t.Fatal("publish stored at zero nodes while a reachable core was attached")
 	}
 }

--- a/internal/mesh/overlay_seed_on_learn_test.go
+++ b/internal/mesh/overlay_seed_on_learn_test.go
@@ -1,0 +1,70 @@
+package mesh
+
+import (
+	"testing"
+
+	"github.com/redstone-md/moss/internal/gossip"
+	"github.com/redstone-md/moss/internal/nat"
+)
+
+// announcementFrom builds the signed supernode envelope `announcer` would send
+// about itself. The signature is verified against AdvertisedPeerID, so it has
+// to be a real identity rather than a made-up id.
+func announcementFrom(announcer *Node, addr string, natType nat.Type, reachable, relayCapable bool) gossip.Envelope {
+	return announcer.signSupernodeEnvelope(gossip.Envelope{
+		Type:                   gossip.TypeSupernodeAnnounce,
+		AdvertisedPeerID:       announcer.localPeerID(),
+		AdvertisedAddr:         addr,
+		AdvertisedNATType:      string(natType),
+		AdvertisedReachable:    reachable,
+		AdvertisedRelayCapable: relayCapable,
+	})
+}
+
+// A DM subscribes and goes looking for its counterpart within seconds of the
+// node starting. The routing table used to be filled only by the 30s republish
+// pass, so every lookup in that first window queried an empty table and could
+// only return nothing — while the peers it needed were already known. The table
+// has to grow when a peer is learned, not on a timer.
+func TestOverlayTableGrowsWhenARoutablePeerIsLearned(t *testing.T) {
+	node, err := NewNode("mesh-overlay-seed-on-learn", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	announcer, err := NewNode("mesh-overlay-seed-on-learn", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode announcer: %v", err)
+	}
+	if got := node.overlayTable.Len(); got != 0 {
+		t.Fatalf("table starts with %d contacts, want 0", got)
+	}
+
+	env := announcementFrom(announcer, "203.0.113.7:4001", nat.TypePublic, true, true)
+	node.handleKnownPeerEnvelope(nil, env, gossip.TypeSupernodeAnnounce, true)
+
+	if got := node.overlayTable.Len(); got != 1 {
+		t.Fatalf("table holds %d contacts after learning a routable peer, want 1 "+
+			"— a lookup in the first 30s must have somewhere to ask", got)
+	}
+}
+
+// The overlay only routes through nodes that can be dialed. A peer behind a NAT
+// is a client of the layer, never a hop, so learning one must not grow the
+// table.
+func TestOverlayTableIgnoresAPeerThatCannotBeDialed(t *testing.T) {
+	node, err := NewNode("mesh-overlay-seed-skips-nat", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	announcer, err := NewNode("mesh-overlay-seed-skips-nat", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode announcer: %v", err)
+	}
+
+	env := announcementFrom(announcer, "203.0.113.9:4001", nat.TypeSymmetric, false, false)
+	node.handleKnownPeerEnvelope(nil, env, gossip.TypeSupernodeAnnounce, true)
+
+	if got := node.overlayTable.Len(); got != 0 {
+		t.Fatalf("table holds %d contacts, want 0 — a NAT'd peer is not a hop", got)
+	}
+}

--- a/internal/mesh/overlay_seed_tally_test.go
+++ b/internal/mesh/overlay_seed_tally_test.go
@@ -1,0 +1,89 @@
+package mesh
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/redstone-md/moss/internal/overlay"
+)
+
+// A seed pass is the only thing that fills the routing table, and an empty
+// table makes every layer above it report "nobody is there". These assert the
+// tally names the gate that actually closed, because the whole point of the
+// counters is to tell those cases apart from the outside.
+func TestOverlaySeedTallyNamesTheGateThatRejected(t *testing.T) {
+	self, ok := overlay.IDFromHex(strings.Repeat("11", overlay.IDLen))
+	if !ok {
+		t.Fatal("self id")
+	}
+	node := &Node{overlayTable: overlay.NewTable(self, 0)}
+
+	routable := knownPeer{
+		id:              strings.Repeat("ab", overlay.IDLen),
+		addr:            "203.0.113.7:4001",
+		publicReachable: true,
+	}
+	cases := []struct {
+		name string
+		peer knownPeer
+		want overlaySeedTally
+	}{
+		{
+			name: "routable contact is added",
+			peer: routable,
+			want: overlaySeedTally{considered: 1, added: 1},
+		},
+		{
+			name: "a NAT'd peer is not a hop",
+			peer: knownPeer{id: routable.id, addr: routable.addr},
+			want: overlaySeedTally{considered: 1, notReachable: 1},
+		},
+		{
+			name: "reachable but nowhere to dial",
+			peer: knownPeer{id: routable.id, publicReachable: true},
+			want: overlaySeedTally{considered: 1, noAddr: 1},
+		},
+		{
+			name: "id is not a point in the keyspace",
+			peer: knownPeer{id: "nothex", addr: routable.addr, publicReachable: true},
+			want: overlaySeedTally{considered: 1, badID: 1},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got overlaySeedTally
+			node.noteOverlayContact(tc.peer, &got)
+			if got != tc.want {
+				t.Fatalf("tally = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The counters have to survive the walk, not just a single call: the field we
+// read in telemetry is the sum over every known peer.
+func TestOverlaySeedTallyAccumulatesAcrossPeers(t *testing.T) {
+	self, ok := overlay.IDFromHex(strings.Repeat("22", overlay.IDLen))
+	if !ok {
+		t.Fatal("self id")
+	}
+	node := &Node{
+		overlayTable: overlay.NewTable(self, 0),
+		knownPeers: map[string]knownPeer{
+			"a": {id: strings.Repeat("aa", overlay.IDLen), addr: "203.0.113.7:4001", publicReachable: true},
+			"b": {id: strings.Repeat("bb", overlay.IDLen), addr: "203.0.113.8:4001", publicReachable: true},
+			"c": {id: strings.Repeat("cc", overlay.IDLen), addr: "203.0.113.9:4001"},
+			"d": {id: strings.Repeat("dd", overlay.IDLen), publicReachable: true},
+		},
+	}
+
+	got := node.overlaySeedFromKnownPeers()
+	want := overlaySeedTally{considered: 4, added: 2, notReachable: 1, noAddr: 1}
+	if got != want {
+		t.Fatalf("tally = %+v, want %+v", got, want)
+	}
+	if n := node.overlayTable.Len(); n != 2 {
+		t.Fatalf("table holds %d contacts, want 2 — added count and table must agree", n)
+	}
+}


### PR DESCRIPTION
Topic rendezvous returned nothing on 86% of every lookup the fleet made, and two independent bugs were responsible. Fleet telemetry over 14 days:

| routing table | lookups | found a subscriber |
|---|---|---|
| empty | 5,319 (86%) | 0 |
| 1-4 contacts | 117 | 0 |
| 5+ contacts | 714 | 155 (22%), of which 139 reached the peer |

With a populated table the layer works and completes a path 90% of the time. With an empty one it cannot. So the question was never "is rendezvous broken" — it was "why is the table empty exactly when a lookup needs it".

### The table filled too late

`overlay_publish` reports an empty table on 0.1% of its passes; `topic_rendezvous` reports one on 86% of its lookups. Same nodes, different moment. The table was only seeded by the 30s republish pass, while a DM goes looking for its counterpart within seconds of startup — so the first lookups always queried nothing, and the peers they needed were already known by then.

The table now grows when a routable peer is learned, which is the event that makes a contact usable, rather than on a timer that has no relation to it.

### And discovery never asked again

`maybeDiscoverTopicPeers` skipped a topic whose mesh looked full. A GRAFT marks its target as a mesh peer before that peer has said anything about the channel, so a node with no idea who is on a topic could fill its mesh with strangers and read as healthy for as long as it took them to answer PRUNE — every pass, forever. Measured on a live pair: 16,933 inbound PRUNEs.

`ConfirmedMeshPeers` counts only members that have themselves claimed the channel. The same run afterwards: 0 PRUNEs, rendezvous attempts 3 → 12.

### Also here

- `seed_considered` / `seed_added` / `seed_rej_*` on `overlay_publish`, so an empty table names the gate that emptied it instead of leaving it to be guessed at. First reading: 2,189 of 2,318 known peers rejected as unreachable — only public nodes are eligible hops, which is what makes the seeding window so narrow.
- `topic_key` on lookups and `topic_keys` on publishes, so the two sides can be lined up. This retired the leading hypothesis: both ends derive identical keys, so `found=0` was never a key mismatch.

### Tests

`ConfirmedMeshPeers` counting, the seed tally's per-gate rejections, and table growth on learning a routable peer (with the NAT'd-peer case asserting the opposite). 273 pass across mesh, gossip and overlay; build and vet clean.
