### PR TITLE
fix(transport): stop a closing UDP session from killing the host process

### DIFF
--- a/internal/transport/udp_session.go
+++ b/internal/transport/udp_session.go
@@ -152,10 +152,7 @@ func (c *udpCarrier) WritePacket(packet []byte) error {
 
 func (c *udpCarrier) ReadPacket() ([]byte, error) {
 	select {
-	case packet, ok := <-c.incoming:
-		if !ok {
-			return nil, io.EOF
-		}
+	case packet := <-c.incoming:
 		return packet, nil
 	case <-c.closed:
 		return nil, io.EOF
@@ -166,11 +163,16 @@ func (c *udpCarrier) RemoteAddr() net.Addr {
 	return c.remote
 }
 
+// Close and closeFromListener deliberately leave `incoming` open. The read
+// loop runs on its own goroutine and can be inside enqueue's send at the exact
+// moment a session closes; closing the channel it is sending on turned that
+// race into `panic: send on closed channel`, which takes the whole host process
+// down because moss is linked as a shared library. `closed` alone is enough to
+// end reads — a channel nobody holds is collected either way.
 func (c *udpCarrier) Close() error {
 	c.once.Do(func() {
 		c.listener.removeSession(c.remote.String(), c)
 		close(c.closed)
-		close(c.incoming)
 	})
 	return nil
 }
@@ -178,7 +180,6 @@ func (c *udpCarrier) Close() error {
 func (c *udpCarrier) closeFromListener() {
 	c.once.Do(func() {
 		close(c.closed)
-		close(c.incoming)
 	})
 }
 

--- a/internal/transport/udp_session_close_race_test.go
+++ b/internal/transport/udp_session_close_race_test.go
@@ -1,0 +1,47 @@
+package transport
+
+import (
+	"net"
+	"testing"
+)
+
+// A UDP session can close while the listener's read loop is midway through
+// delivering a packet to it — the two run on different goroutines and nothing
+// orders them, so enqueue can pass its `closed` check and then send after the
+// close completes. While Close also closed `incoming`, that window was a
+// `panic: send on closed channel`, and it is fatal for the whole process: moss
+// is linked into its host as a shared library, so the host dies with it. It was
+// hit on an ordinary probe run, not under stress.
+//
+// The window itself is too narrow to reproduce by racing goroutines — this
+// asserts the invariant that removes it instead: after a close, `incoming` is
+// still open and a send on it is safe.
+func TestCloseLeavesTheIncomingChannelOpen(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		close func(*udpCarrier)
+	}{
+		{"from listener", (*udpCarrier).closeFromListener},
+		{"by the session", func(c *udpCarrier) { _ = c.Close() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			listener := &UDPListener{sessions: make(map[string]*udpCarrier)}
+			carrier := &udpCarrier{
+				listener: listener,
+				remote:   &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 40001},
+				incoming: make(chan []byte, 1),
+				closed:   make(chan struct{}),
+			}
+
+			tc.close(carrier)
+
+			// The send the read loop would be making. On a closed channel this
+			// panics and takes the host down with it.
+			select {
+			case carrier.incoming <- []byte{0x01}:
+			default:
+				t.Fatal("buffered channel refused a send after close")
+			}
+		})
+	}
+}


### PR DESCRIPTION
A 120s probe run died on this, with no stress involved:

```
panic: send on closed channel
transport.(*udpCarrier).enqueue(...)      udp_session.go:192
transport.(*UDPListener).handleData(...)  udp_session.go:36
transport.(*UDPListener).readLoop(...)    udp_handshake.go:38
```

The listener's read loop and a session close run on different goroutines and nothing orders them, so `enqueue` can pass its `closed` check and then send on `incoming` after `Close` has closed it. Because moss is linked into its host as a shared library, that panic is not a lost session — it takes the entire application down with it.

Close now leaves `incoming` open. Nothing ever needed it closed: `closed` already ends `ReadPacket`, and a channel nobody holds is collected regardless. This removes the window instead of narrowing it, and drops the now-unreachable `!ok` branch.

### On the test

Racing goroutines does not reproduce this — 200 rounds under `-race` never hit the window. The test asserts the invariant that eliminates it instead: after either close path, a send on `incoming` is still safe. It fails on `main` and passes here, which is the property that matters.

Transport, mesh and gossip suites pass; build and vet clean.
