### PR TITLE
fix(gossip): stop a mesh of strangers from crowding out the real subscriber

### DIFF
--- a/internal/mesh/mesh_minimum_confirmed_test.go
+++ b/internal/mesh/mesh_minimum_confirmed_test.go
@@ -1,0 +1,45 @@
+package mesh
+
+import (
+	"testing"
+)
+
+// The counterpart of a DM is connected and known to be on the channel, but the
+// mesh is already "full" of peers grafted on spec that have never claimed it.
+// Counting those made ensureTopicMeshMinimum return immediately, so the one
+// peer that actually subscribes was never grafted — and since publishing only
+// reaches known subscribers, both ends published into the substrate and neither
+// ever heard the other. Observed live: 83 KeyPackages published successfully,
+// none of which reached the counterpart sitting in the same peer table.
+func TestMeshMinimumGraftsARealSubscriberOverOptimisticStrangers(t *testing.T) {
+	node, err := NewNode("mesh-minimum-confirmed", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	const channel = "dm-control"
+	node.pubsub.Subscribe(channel)
+
+	// A mesh full of peers that were grafted but have never claimed the channel.
+	for _, id := range []string{"s1", "s2", "s3", "s4", "s5", "s6"} {
+		node.pubsub.SetMeshPeer(channel, id, true)
+	}
+	if got := len(node.pubsub.MeshPeers(channel)); got < node.config.GossipSub.DLo {
+		t.Fatalf("test setup: mesh holds %d, needs at least DLo=%d to reproduce",
+			got, node.config.GossipSub.DLo)
+	}
+
+	// The counterpart: connected, and known to subscribe to this channel.
+	const counterpart = "counterpart"
+	node.mu.Lock()
+	node.peers[counterpart] = &peerConn{id: counterpart, addr: "198.51.100.7:41000"}
+	node.mu.Unlock()
+	node.pubsub.SetPeerSubscription(counterpart, channel, true)
+
+	node.ensureTopicMeshMinimum(channel)
+
+	if !node.pubsub.InMesh(channel, counterpart) {
+		t.Fatal("the one confirmed subscriber was not grafted — a mesh of " +
+			"unconfirmed strangers must not count as full, or publishes never " +
+			"reach the counterpart")
+	}
+}

--- a/internal/mesh/node_peer_discovery.go
+++ b/internal/mesh/node_peer_discovery.go
@@ -303,11 +303,22 @@ func (n *Node) maintainTopicMesh(channel string) {
 }
 
 func (n *Node) ensureTopicMeshMinimum(channel string) {
-	meshPeers := n.pubsub.MeshPeers(channel)
-	if len(meshPeers) >= n.config.GossipSub.DLo {
+	// Confirmed members decide whether the mesh still needs filling. Grafting
+	// marks a peer in-mesh before it has said anything about the channel, so
+	// counting those makes a mesh of six strangers look complete and stops us
+	// grafting the one peer that is actually on the topic. They answer PRUNE,
+	// the mesh empties, and the next pass grafts six more strangers — while the
+	// counterpart, already connected, is never grafted at all. Publishing only
+	// reaches peers known to subscribe, so both ends then publish into the
+	// substrate and neither ever hears the other.
+	confirmed := n.pubsub.ConfirmedMeshPeers(channel)
+	if confirmed >= n.config.GossipSub.DLo {
 		return
 	}
-	candidates := n.selectMeshCandidates(channel, n.config.GossipSub.D-len(meshPeers))
+	// The room to graft into is measured the same way. Sizing it by the total
+	// mesh gave `D - 6 = 0` slots whenever six strangers were already grafted,
+	// so even a peer known to subscribe could never be selected.
+	candidates := n.selectMeshCandidates(channel, n.config.GossipSub.D-confirmed)
 	for _, peerID := range candidates {
 		n.mu.RLock()
 		peer := n.peers[peerID]


### PR DESCRIPTION
`ensureTopicMeshMinimum` measured a topic's mesh with `MeshPeers`, which counts peers grafted on spec that have never claimed the channel. That broke grafting two ways at once:

- the `DLo` check returns early, so no grafting happens; and
- the slot count is `D - len(meshPeers)`, which is **0** once six strangers are in — so even reaching `selectMeshCandidates` could not select anyone.

Why it matters: publishing only reaches peers known to subscribe, and a subscription is learned from a GRAFT and nothing else. A counterpart that is connected and genuinely on the channel therefore never receives a publish. Both ends publish into the substrate, neither hears the other, and every counter reads healthy the whole time.

Both quantities now come from `ConfirmedMeshPeers` — the same correction already applied to `maybeDiscoverTopicPeers` in #18. This was the identical bug in the second of the two places that consult the mesh; fixing only the first left the door shut.

### Test

A mesh of six unconfirmed peers must not stop the one confirmed subscriber from being grafted. Fails on `main` — and note it fails there *even with the DLo check corrected alone*, which is how the slot-count half surfaced.

### Scope, honestly

This is a real defect and the test pins it, but it is **not** what unblocked the DM failure I was chasing. That turned out to be a control-frame dedup in mosh dropping every handshake retransmission. This ships on its own merits.

mesh, gossip and transport suites pass; build and vet clean.
