### PR TITLE
fix(mesh): stop application delivery from stalling the read loop

### DIFF
--- a/internal/mesh/local_delivery_test.go
+++ b/internal/mesh/local_delivery_test.go
@@ -1,0 +1,81 @@
+package mesh
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// Delivery to the application is a synchronous callback that decrypts and
+// writes to disk. It used to be fed straight from the read loop, so a file
+// transfer's chunks filled the shared queue, the send blocked, the read loop
+// stopped, and the transport's inbound buffer overflowed — discarding whatever
+// arrived next, pings included. Measured on a live pair: 36 dropped packets,
+// transfers stuck at 63%, and sessions dying at 37s on a healthy link.
+//
+// Enqueueing must therefore never block, however slow the application is.
+func TestSlowDeliveryNeverBlocksTheReader(t *testing.T) {
+	node, err := NewNode("mesh-local-delivery", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+
+	release := make(chan struct{})
+	var once sync.Once
+	node.SetMessageCallback(func(string, [32]byte, []byte) {
+		<-release // the application is busy for as long as we like
+	})
+	defer once.Do(func() { close(release) })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Comfortably more than one queue's worth: past the depth the sends
+		// must still return, dropping rather than waiting.
+		for i := 0; i < localDeliveryQueueDepth+64; i++ {
+			node.enqueueLocal(dispatchMessage{channel: "chat", data: []byte("x")})
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("enqueueLocal blocked while the application was slow — the read " +
+			"loop stalls behind it and the transport buffer overflows")
+	}
+}
+
+// One queue per channel. A blob transfer that occupies its own worker must not
+// delay control traffic, which is the only reason ordering is kept per channel
+// rather than globally.
+func TestASlowChannelDoesNotDelayAnother(t *testing.T) {
+	node, err := NewNode("mesh-local-delivery-isolation", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+
+	blocked := make(chan struct{})
+	arrived := make(chan string, 4)
+	var once sync.Once
+	node.SetMessageCallback(func(channel string, _ [32]byte, _ []byte) {
+		if channel == "blob" {
+			<-blocked
+			return
+		}
+		arrived <- channel
+	})
+	defer once.Do(func() { close(blocked) })
+
+	node.enqueueLocal(dispatchMessage{channel: "blob", data: []byte("chunk")})
+	node.enqueueLocal(dispatchMessage{channel: "control", data: []byte("keypkg")})
+
+	select {
+	case got := <-arrived:
+		if got != "control" {
+			t.Fatalf("delivered %q, want the control message", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a stalled blob transfer held up control traffic — the two must " +
+			"drain on separate workers")
+	}
+}

--- a/internal/mesh/node_envelope.go
+++ b/internal/mesh/node_envelope.go
@@ -144,11 +144,74 @@ func (n *Node) deliverLocal(env gossip.Envelope) {
 	}
 	var sender [32]byte
 	copy(sender[:], env.SenderID)
-	n.dispatchCh <- dispatchMessage{
+	n.enqueueLocal(dispatchMessage{
 		// Hand the application its bare channel, not the opaque room topic.
 		channel: n.localChannel(env.Channel),
 		sender:  sender,
 		data:    plaintext,
+	})
+}
+
+// localDeliveryQueueDepth is per channel. Deep enough to absorb a file
+// transfer's chunks while the application decrypts and writes them, because the
+// alternative is not "wait a moment" but "lose packets in the transport buffer
+// and take the pings with them".
+const localDeliveryQueueDepth = 4096
+
+// enqueueLocal hands a message to its channel's delivery worker and never
+// blocks the caller.
+//
+// The read loop calls this. Blocking here stops that loop, and a stopped read
+// loop overflows the transport's inbound buffer, which discards whatever
+// arrives next — including the pings a session dies without. A dropped message
+// on one channel is a bounded, counted loss; a stalled reader is an unbounded,
+// invisible one. The first is strictly better, so the send is non-blocking and
+// the overflow is recorded.
+func (n *Node) enqueueLocal(msg dispatchMessage) {
+	n.localMu.Lock()
+	queue, ok := n.localQueues[msg.channel]
+	if !ok {
+		queue = make(chan dispatchMessage, localDeliveryQueueDepth)
+		if n.localQueues == nil {
+			n.localQueues = make(map[string]chan dispatchMessage)
+		}
+		n.localQueues[msg.channel] = queue
+		n.wg.Add(1)
+		go n.localDeliveryWorker(queue)
+	}
+	n.localMu.Unlock()
+
+	select {
+	case queue <- msg:
+	default:
+		n.countInbound("__local_delivery_dropped__")
+	}
+}
+
+// localDeliveryWorker drains one channel's queue in order. One worker per
+// channel: ordering is preserved where it is meaningful, and a slow transfer on
+// one channel cannot delay control traffic on another.
+func (n *Node) localDeliveryWorker(queue chan dispatchMessage) {
+	defer n.wg.Done()
+	for {
+		n.mu.RLock()
+		root := n.rootCtx
+		n.mu.RUnlock()
+		var done <-chan struct{}
+		if root != nil {
+			done = root.Done()
+		}
+		select {
+		case <-done:
+			return
+		case msg := <-queue:
+			n.mu.RLock()
+			cb := n.messageCB
+			n.mu.RUnlock()
+			if cb != nil {
+				cb(msg.channel, msg.sender, msg.data)
+			}
+		}
 	}
 }
 

--- a/internal/mesh/node_lifecycle.go
+++ b/internal/mesh/node_lifecycle.go
@@ -114,6 +114,7 @@ func NewNodeWithIdentity(meshID string, psk []byte, cfg Config, identity *mcrypt
 		holePunchWait:    make(map[string]holePunchRequest),
 		dispatchSem:      make(chan struct{}, 500),
 		dispatchCh:       make(chan any, 1024),
+		localQueues:      make(map[string]chan dispatchMessage),
 	}
 	node.natProfile.Store(nat.Profile{Type: nat.TypeUnknown})
 	if cfg.Telemetry.Enabled {

--- a/internal/mesh/node_types.go
+++ b/internal/mesh/node_types.go
@@ -136,6 +136,22 @@ type Node struct {
 	eventCB          EventCallback
 	relayCB          RelayCallback
 	dispatchCh       chan any
+
+	// Per-channel delivery queues, each drained by its own worker.
+	//
+	// Delivery to the application is a synchronous FFI callback that decrypts
+	// and writes to disk. Feeding it from the read loop meant one slow channel
+	// stalled everything: a blob's chunks filled the shared dispatch queue,
+	// deliverLocal blocked, readPeer stopped reading, and the transport's
+	// 256-packet buffer overflowed — silently discarding whatever was behind,
+	// pings included. That is both the file transfers that stick at 63% and the
+	// sessions that die at 37s on a healthy link.
+	//
+	// One queue per channel keeps ordering where it matters (within a channel)
+	// while a slow blob transfer can no longer stall control traffic, and the
+	// read loop never blocks on delivery at all.
+	localMu     sync.Mutex
+	localQueues map[string]chan dispatchMessage
 }
 
 type peerConn struct {


### PR DESCRIPTION
Delivery to the application is a synchronous callback that decrypts and writes to disk. It was fed from a single shared queue drained by one goroutine, and `deliverLocal`'s send into it **blocked**. A file transfer's chunks filled the queue, the send blocked, `readPeer` stopped reading, and the transport's 256-packet inbound buffer overflowed — discarding whatever arrived next, with no record anywhere.

Both symptoms were measured on a live pair today:

- **transfers stuck forever** at 63% / 32% / 0% — a lost chunk is never re-sent;
- **sessions dying at ~37s on a healthy link** — the packets thrown away behind the stall include the pings a peer counts six of before giving up.

```
stream_drops = 36, all on the default stream
```

The comment already sitting on that counter described this exact failure; nothing had ever acted on it.

### What changes

One queue and one worker **per channel**:

- a slow transfer on one channel can no longer delay control traffic on another — that is the only reason ordering needs to be per-channel rather than global;
- the enqueue **never blocks**. A dropped message on one channel is a bounded, counted loss (`__local_delivery_dropped__`); a stalled reader is an unbounded, invisible one that takes the whole session with it.

Note the `dispatchSem` this replaces for the delivery path was inert: a single goroutine acquired and released it inside one iteration, so it never permitted any concurrency at all.

### Tests

Two properties, both verified to fail against a blocking enqueue (checked by temporarily restoring the blocking send):

- enqueueing returns even when the application is wedged and the queue is past its depth;
- a stalled blob channel does not hold up a control message behind it.

mesh, gossip and transport suites pass; build and vet clean.