### PR TITLE
feat(mesh): let one node hold several rooms

### DIFF
--- a/cmd/moss-ffi/main.go
+++ b/cmd/moss-ffi/main.go
@@ -194,6 +194,76 @@ func Moss_Subscribe(handle C.MossHandle, channel *C.char) C.int32_t {
 	return C.int32_t(node.Subscribe(C.GoString(channel)))
 }
 
+// Moss_JoinRoom, Moss_SubscribeRoom, Moss_PublishRoom and Moss_UnsubscribeRoom
+// let ONE node serve several rooms. A host that gave each conversation its own
+// room had to start a node per conversation, and node identity is per process,
+// so every one of those nodes presented the same peer id from a different port
+// — remote peers keep one session per identity and closed the rest on arrival.
+//
+// The room-less calls above are unchanged and still mean "this node's own
+// room", so a host that does not care never sees any of this. Callers older
+// than this build simply lack the symbols; treat a missing one as "this moss
+// cannot share a node".
+
+//export Moss_JoinRoom
+func Moss_JoinRoom(handle C.MossHandle, meshID *C.char, psk *C.uint8_t, pskLength C.uint32_t) C.int32_t {
+	node, code := getNode(int64(handle))
+	if code != mesh.MOSS_OK {
+		return C.int32_t(code)
+	}
+	if meshID == nil {
+		return C.int32_t(mesh.MOSS_ERR_CONFIG_INVALID)
+	}
+	var secret []byte
+	if psk != nil && pskLength > 0 {
+		secret = bytesFromPointer(psk, int(pskLength))
+	}
+	return C.int32_t(node.JoinRoom(C.GoString(meshID), secret))
+}
+
+//export Moss_LeaveRoom
+func Moss_LeaveRoom(handle C.MossHandle, meshID *C.char) C.int32_t {
+	node, code := getNode(int64(handle))
+	if code != mesh.MOSS_OK {
+		return C.int32_t(code)
+	}
+	if meshID == nil {
+		return C.int32_t(mesh.MOSS_ERR_CONFIG_INVALID)
+	}
+	return C.int32_t(node.LeaveRoom(C.GoString(meshID)))
+}
+
+//export Moss_SubscribeRoom
+func Moss_SubscribeRoom(handle C.MossHandle, meshID *C.char, channel *C.char) C.int32_t {
+	node, code := getNode(int64(handle))
+	if code != mesh.MOSS_OK {
+		return C.int32_t(code)
+	}
+	return C.int32_t(node.SubscribeRoom(C.GoString(meshID), C.GoString(channel)))
+}
+
+//export Moss_UnsubscribeRoom
+func Moss_UnsubscribeRoom(handle C.MossHandle, meshID *C.char, channel *C.char) C.int32_t {
+	node, code := getNode(int64(handle))
+	if code != mesh.MOSS_OK {
+		return C.int32_t(code)
+	}
+	return C.int32_t(node.UnsubscribeRoom(C.GoString(meshID), C.GoString(channel)))
+}
+
+//export Moss_PublishRoom
+func Moss_PublishRoom(handle C.MossHandle, meshID *C.char, channel *C.char, data *C.uint8_t, length C.uint32_t) C.int32_t {
+	node, code := getNode(int64(handle))
+	if code != mesh.MOSS_OK {
+		return C.int32_t(code)
+	}
+	if code := validatePublishPayloadPointer(unsafe.Pointer(data), uint32(length), node.MaxMessageSizeBytes()); code != mesh.MOSS_OK {
+		return C.int32_t(code)
+	}
+	payload := bytesFromPointer(data, int(length))
+	return C.int32_t(node.PublishRoom(C.GoString(meshID), C.GoString(channel), payload))
+}
+
 //export Moss_Connect
 func Moss_Connect(handle C.MossHandle, addr *C.char) C.int32_t {
 	node, code := getNode(int64(handle))

--- a/internal/mesh/errors.go
+++ b/internal/mesh/errors.go
@@ -15,4 +15,5 @@ const (
 	MOSS_ERR_RELAY_FAILED      int32 = -11 // relay send failed (no route, session open failed, or send error)
 	MOSS_ERR_INTERNAL          int32 = -12 // unexpected internal failure (e.g. room-seal crypto error)
 	MOSS_ERR_LISTEN_FAILED     int32 = -13 // could not bind the tcp/udp listener (e.g. port in use, or Go's netpoller can't bind under Wine/Proton). Moss_LastError has the underlying OS error.
+	MOSS_ERR_NOT_IN_ROOM       int32 = -14 // the room was never joined, so this node cannot address or seal for it
 )

--- a/internal/mesh/flood_publish_security_test.go
+++ b/internal/mesh/flood_publish_security_test.go
@@ -57,7 +57,7 @@ func TestLocalPublishDoesNotLeakToUnsubscribedDirectPeer(t *testing.T) {
 			if !ok {
 				continue
 			}
-			if plaintext, opened := spy.openRoom(env.Payload); opened && string(plaintext) == string(payload) {
+			if plaintext, opened := spy.openRoom("", env.Payload); opened && string(plaintext) == string(payload) {
 				t.Fatalf("unsubscribed direct peer cached publish envelope: channel=%q payload=%q", env.Channel, string(plaintext))
 			}
 		}

--- a/internal/mesh/node_envelope.go
+++ b/internal/mesh/node_envelope.go
@@ -136,9 +136,16 @@ func (n *Node) deliverLocal(env gossip.Envelope) {
 	if !n.pubsub.IsLocalSubscriber(env.Channel) {
 		return
 	}
+	// Which room this topic belongs to is not guessable from the wire — the
+	// topic is an HMAC — so it comes from what this node subscribed under. A
+	// topic with no subscription cannot be opened by any key we hold.
+	sub, subscribed := n.subscriptionFor(env.Channel)
+	if !subscribed {
+		return
+	}
 	// Open the room seal; a payload we cannot authenticate (wrong room / PSK) is
 	// dropped rather than handed up.
-	plaintext, ok := n.openRoom(env.Payload)
+	plaintext, ok := n.openRoom(sub.room, env.Payload)
 	if !ok {
 		return
 	}
@@ -146,7 +153,7 @@ func (n *Node) deliverLocal(env gossip.Envelope) {
 	copy(sender[:], env.SenderID)
 	n.enqueueLocal(dispatchMessage{
 		// Hand the application its bare channel, not the opaque room topic.
-		channel: n.localChannel(env.Channel),
+		channel: sub.channel,
 		sender:  sender,
 		data:    plaintext,
 	})

--- a/internal/mesh/node_integration_helpers_test.go
+++ b/internal/mesh/node_integration_helpers_test.go
@@ -431,7 +431,7 @@ func nodeHasCachedPayload(node *Node, channel, payload string) bool {
 			continue
 		}
 		// Cached payloads are room-sealed; open before comparing to plaintext.
-		if plaintext, opened := node.openRoom(env.Payload); opened && string(plaintext) == payload {
+		if plaintext, opened := node.openRoom("", env.Payload); opened && string(plaintext) == payload {
 			return true
 		}
 	}

--- a/internal/mesh/node_lifecycle.go
+++ b/internal/mesh/node_lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"sort"
 	"time"
 
@@ -74,7 +75,8 @@ func NewNodeWithIdentity(meshID string, psk []byte, cfg Config, identity *mcrypt
 		meshID:           meshID,
 		psk:              append([]byte(nil), psk...),
 		roomKey:          deriveRoomKey(meshID, psk),
-		subChannels:      make(map[string]string),
+		subChannels:      make(map[string]subscription),
+		rooms:            make(map[string][]byte),
 		config:           cfg,
 		infoHash:         infoHash,
 		peerID:           peerID,
@@ -296,14 +298,47 @@ func (n *Node) Stop() int32 {
 	return MOSS_OK
 }
 
+// JoinRoom adds a room this node can subscribe and publish in, alongside the
+// one it was constructed with. Idempotent.
+func (n *Node) JoinRoom(meshID string, psk []byte) int32 {
+	if meshID == "" || meshID == n.meshID {
+		return MOSS_ERR_CONFIG_INVALID
+	}
+	if !n.joinRoom(meshID, psk) {
+		return MOSS_ERR_CONFIG_INVALID
+	}
+	return MOSS_OK
+}
+
+// LeaveRoom drops a joined room's key. Subscriptions made in it stop resolving,
+// so anything still arriving for it is dropped rather than delivered. Callers
+// should Unsubscribe first if they want the mesh told; this only forgets the
+// key. The node's own room cannot be left.
+func (n *Node) LeaveRoom(meshID string) int32 {
+	if !n.leaveRoom(meshID) {
+		return MOSS_ERR_NOT_IN_ROOM
+	}
+	return MOSS_OK
+}
+
 func (n *Node) Subscribe(channel string) int32 {
+	return n.SubscribeRoom("", channel)
+}
+
+// SubscribeRoom subscribes inside a named room; an empty room means this node's
+// own. Every room a caller names must have been joined first, or the topic
+// cannot be computed at all.
+func (n *Node) SubscribeRoom(meshID, channel string) int32 {
 	if !validChannel(channel) {
 		return MOSS_ERR_INVALID_CHANNEL
 	}
 	// Everything below the API operates on the opaque room topic; the
 	// application only ever sees the bare channel (see localChannel on delivery).
-	topic := n.roomTopic(channel)
-	n.rememberSubscription(topic, channel)
+	topic := n.roomTopicIn(meshID, channel)
+	if topic == "" {
+		return MOSS_ERR_NOT_IN_ROOM
+	}
+	n.rememberSubscription(topic, meshID, channel)
 	n.pubsub.Subscribe(topic)
 	n.announceLocalSubscription(topic)
 	n.maintainTopicMesh(topic)
@@ -311,10 +346,17 @@ func (n *Node) Subscribe(channel string) int32 {
 }
 
 func (n *Node) Unsubscribe(channel string) int32 {
+	return n.UnsubscribeRoom("", channel)
+}
+
+func (n *Node) UnsubscribeRoom(meshID, channel string) int32 {
 	if !validChannel(channel) {
 		return MOSS_ERR_INVALID_CHANNEL
 	}
-	topic := n.roomTopic(channel)
+	topic := n.roomTopicIn(meshID, channel)
+	if topic == "" {
+		return MOSS_ERR_NOT_IN_ROOM
+	}
 	for _, peerID := range n.pubsub.MeshPeers(topic) {
 		n.mu.RLock()
 		peer := n.peers[peerID]
@@ -330,6 +372,12 @@ func (n *Node) Unsubscribe(channel string) int32 {
 }
 
 func (n *Node) Publish(channel string, data []byte) int32 {
+	return n.PublishRoom("", channel, data)
+}
+
+// PublishRoom publishes inside a named room; an empty room means this node's
+// own.
+func (n *Node) PublishRoom(meshID, channel string, data []byte) int32 {
 	if !validChannel(channel) {
 		return MOSS_ERR_INVALID_CHANNEL
 	}
@@ -344,11 +392,17 @@ func (n *Node) Publish(channel string, data []byte) int32 {
 	}
 	// Seal the payload under the room key so only room members can read it;
 	// substrate peers relay opaque ciphertext under an opaque topic.
-	sealed, err := n.sealRoom(data)
+	sealed, err := n.sealRoomIn(meshID, data)
 	if err != nil {
+		if errors.Is(err, errNotInRoom) {
+			return MOSS_ERR_NOT_IN_ROOM
+		}
 		return MOSS_ERR_INTERNAL
 	}
-	topic := n.roomTopic(channel)
+	topic := n.roomTopicIn(meshID, channel)
+	if topic == "" {
+		return MOSS_ERR_NOT_IN_ROOM
+	}
 	env := n.makePublishEnvelope(topic, sealed)
 	n.cache.Store(env)
 	n.deliverLocal(env)

--- a/internal/mesh/node_room.go
+++ b/internal/mesh/node_room.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"io"
 
 	"golang.org/x/crypto/chacha20poly1305"
@@ -26,6 +27,27 @@ import (
 // A room without a PSK is public: its key derives from the room id alone, which
 // any member already knows — isolation without secrecy. A substrate-only node
 // (empty room, e.g. a spore) has no room key and never touches pub/sub.
+//
+// A node may hold several rooms at once. It is born in the room it was
+// constructed with (its meshID, the default for every room-less call) and can
+// join more with JoinRoom. This is what lets one node serve several
+// conversations: an application that gave each conversation its own room used
+// to need its own node per room, and since node identity is per process, every
+// one of those nodes presented the SAME peer id from a different port — remote
+// peers keep one session per identity and closed the rest on arrival. Measured
+// on three clients over three days: 33k sessions, 95% of them dead inside a
+// second, one identity seen on up to 27 ports in a single hour.
+//
+// Rooms do not interact. Each has its own key, so its topics and its seals are
+// unrelated to any other room's, and a room joined here is wire-identical to
+// the same room on a node that holds nothing else — a new client and an old one
+// compute the same topic and can talk.
+
+// errNotInRoom is what publishing into a room this node never joined returns.
+// Silently falling back to the node's own room would put the payload on a topic
+// the intended peers do not read, which looks like a delivery failure hours
+// later rather than a mistake at the call site.
+var errNotInRoom = errors.New("not in room")
 
 // deriveRoomKey returns the 32-byte room key, computed once at construction.
 func deriveRoomKey(meshID string, psk []byte) []byte {
@@ -43,35 +65,107 @@ func deriveRoomKey(meshID string, psk []byte) []byte {
 	return key
 }
 
-// roomTopic maps an application channel to the opaque wire topic used on the
-// shared substrate. It is deterministic per (room key, channel), so every
-// member of a room computes the same topic while outsiders — who lack the room
-// key — cannot recover the channel name or correlate topics across rooms.
-func (n *Node) roomTopic(channel string) string {
-	if n.meshID == "" || len(n.roomKey) == 0 {
-		return channel
+// joinRoom derives and stores a room's key. Joining a room already held is a
+// no-op rather than an error: the caller re-joining on reconnect must not have
+// to track what it already did.
+func (n *Node) joinRoom(meshID string, psk []byte) bool {
+	if meshID == "" {
+		return false
 	}
-	mac := hmac.New(sha256.New, n.roomKey)
+	key := deriveRoomKey(meshID, psk)
+	if len(key) == 0 {
+		return false
+	}
+	n.mu.Lock()
+	if n.rooms == nil {
+		n.rooms = make(map[string][]byte)
+	}
+	n.rooms[meshID] = key
+	n.mu.Unlock()
+	return true
+}
+
+// leaveRoom forgets a room's key. Subscriptions in it stop resolving, so
+// anything still arriving for that room is dropped rather than delivered. The
+// node's own room cannot be left — it is what the room-less calls mean.
+func (n *Node) leaveRoom(meshID string) bool {
+	if meshID == "" || meshID == n.meshID {
+		return false
+	}
+	n.mu.Lock()
+	_, held := n.rooms[meshID]
+	delete(n.rooms, meshID)
+	n.mu.Unlock()
+	return held
+}
+
+// roomKeyFor returns the key of a room this node holds. The empty room id means
+// "the node's own room", which is what every room-less call uses.
+func (n *Node) roomKeyFor(meshID string) []byte {
+	if meshID == "" || meshID == n.meshID {
+		return n.roomKey
+	}
+	n.mu.RLock()
+	key := n.rooms[meshID]
+	n.mu.RUnlock()
+	return key
+}
+
+// roomTopic maps an application channel to the opaque wire topic used on the
+// shared substrate, in this node's own room.
+func (n *Node) roomTopic(channel string) string {
+	return n.roomTopicIn("", channel)
+}
+
+// roomTopicIn is roomTopic for a named room. It is deterministic per (room key,
+// channel), so every member of a room computes the same topic while outsiders —
+// who lack the room key — cannot recover the channel name or correlate topics
+// across rooms. A room this node does not hold has no topic; the caller must
+// treat "" as "cannot address that room".
+func (n *Node) roomTopicIn(meshID, channel string) string {
+	key := n.roomKeyFor(meshID)
+	if len(key) == 0 {
+		// The node's own room being keyless means a substrate-only node, where
+		// channels ARE topics. A named room being keyless means it was never
+		// joined, which is not the same thing and must not silently publish in
+		// the clear under the bare channel name.
+		if meshID == "" || meshID == n.meshID {
+			return channel
+		}
+		return ""
+	}
+	mac := hmac.New(sha256.New, key)
 	mac.Write([]byte("moss-room-topic|"))
 	mac.Write([]byte(channel))
 	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)[:16])
 }
 
-// localChannel is the inverse of roomTopic for delivery: HMAC topics are not
-// reversible, so it looks up the bare channel this node subscribed under. A
-// topic we never subscribed to (should not be delivered) falls through
-// unchanged.
+// subscription is what a wire topic was subscribed under: HMAC topics are not
+// reversible, so delivery looks the pair up rather than computing it.
+type subscription struct {
+	room    string
+	channel string
+}
+
+// localChannel is the inverse of roomTopic for delivery. A topic we never
+// subscribed to (should not be delivered) falls through unchanged.
 func (n *Node) localChannel(topic string) string {
 	if n.meshID == "" {
 		return topic
 	}
-	n.mu.RLock()
-	channel, ok := n.subChannels[topic]
-	n.mu.RUnlock()
-	if ok {
-		return channel
+	if sub, ok := n.subscriptionFor(topic); ok {
+		return sub.channel
 	}
 	return topic
+}
+
+// subscriptionFor reports which room and channel a wire topic was subscribed
+// under, and whether this node subscribed to it at all.
+func (n *Node) subscriptionFor(topic string) (subscription, bool) {
+	n.mu.RLock()
+	sub, ok := n.subChannels[topic]
+	n.mu.RUnlock()
+	return sub, ok
 }
 
 // localChannels maps a slice of wire topics back to bare channels for reporting
@@ -88,11 +182,12 @@ func (n *Node) localChannels(topics []string) []string {
 	return out
 }
 
-// rememberSubscription / forgetSubscription track the topic->channel mapping so
-// delivered messages can be reported under their application channel name.
-func (n *Node) rememberSubscription(topic, channel string) {
+// rememberSubscription / forgetSubscription track the topic->(room, channel)
+// mapping so delivered messages can be opened with the right room key and
+// reported under their application channel name.
+func (n *Node) rememberSubscription(topic, room, channel string) {
 	n.mu.Lock()
-	n.subChannels[topic] = channel
+	n.subChannels[topic] = subscription{room: room, channel: channel}
 	n.mu.Unlock()
 }
 
@@ -102,14 +197,23 @@ func (n *Node) forgetSubscription(topic string) {
 	n.mu.Unlock()
 }
 
-// sealRoom AEAD-encrypts a pub/sub payload under the room key. Substrate peers
-// that forward the message never hold the key, so they relay ciphertext they
-// cannot read. Returns the input unchanged for a roomless (substrate-only) node.
+// sealRoom AEAD-encrypts a pub/sub payload under this node's own room key.
 func (n *Node) sealRoom(plaintext []byte) ([]byte, error) {
-	if n.meshID == "" || len(n.roomKey) == 0 {
-		return plaintext, nil
+	return n.sealRoomIn("", plaintext)
+}
+
+// sealRoomIn is sealRoom for a named room. Substrate peers that forward the
+// message never hold the key, so they relay ciphertext they cannot read.
+// Returns the input unchanged for a roomless (substrate-only) node.
+func (n *Node) sealRoomIn(meshID string, plaintext []byte) ([]byte, error) {
+	key := n.roomKeyFor(meshID)
+	if len(key) == 0 {
+		if meshID == "" || meshID == n.meshID {
+			return plaintext, nil
+		}
+		return nil, errNotInRoom
 	}
-	aead, err := chacha20poly1305.New(n.roomKey)
+	aead, err := chacha20poly1305.New(key)
 	if err != nil {
 		return nil, err
 	}
@@ -120,14 +224,18 @@ func (n *Node) sealRoom(plaintext []byte) ([]byte, error) {
 	return aead.Seal(nonce, nonce, plaintext, nil), nil
 }
 
-// openRoom reverses sealRoom. It returns ok=false when the payload was sealed
-// for a different room / with a different PSK, so a message we cannot
-// authenticate is dropped rather than delivered.
-func (n *Node) openRoom(payload []byte) ([]byte, bool) {
-	if n.meshID == "" || len(n.roomKey) == 0 {
-		return payload, true
+// openRoom reverses sealRoom for a named room. It returns ok=false when the
+// payload was sealed for a different room / with a different PSK, so a message
+// we cannot authenticate is dropped rather than delivered.
+func (n *Node) openRoom(meshID string, payload []byte) ([]byte, bool) {
+	key := n.roomKeyFor(meshID)
+	if len(key) == 0 {
+		if meshID == "" || meshID == n.meshID {
+			return payload, true
+		}
+		return nil, false
 	}
-	aead, err := chacha20poly1305.New(n.roomKey)
+	aead, err := chacha20poly1305.New(key)
 	if err != nil {
 		return nil, false
 	}

--- a/internal/mesh/node_room_multi_test.go
+++ b/internal/mesh/node_room_multi_test.go
@@ -1,0 +1,143 @@
+package mesh
+
+import (
+	"testing"
+	"time"
+
+	"github.com/redstone-md/moss/internal/gossip"
+)
+
+// One node holding several rooms must be indistinguishable, on the wire, from
+// several nodes each holding one. This is the property the whole change rests
+// on: without it a client that consolidates its conversations onto one node
+// stops being able to talk to every already-released client, which computes its
+// topics from a node whose own room is the pair's.
+func TestJoinedRoomIsWireIdenticalToOwningIt(t *testing.T) {
+	shared, err := NewNode("room-a", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	if code := shared.JoinRoom("room-b", nil); code != MOSS_OK {
+		t.Fatalf("JoinRoom: %d", code)
+	}
+	// What an already-released client looks like: one node, one room.
+	legacy, err := NewNode("room-b", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+
+	got := shared.roomTopicIn("room-b", "mls-data/session-1")
+	want := legacy.roomTopic("mls-data/session-1")
+	if got == "" || got != want {
+		t.Fatalf("topic in a joined room is %q, the same room owned outright is %q — "+
+			"a consolidated client would publish where nobody is listening", got, want)
+	}
+
+	sealed, err := shared.sealRoomIn("room-b", []byte("hello"))
+	if err != nil {
+		t.Fatalf("sealRoomIn: %v", err)
+	}
+	plaintext, ok := legacy.openRoom("", sealed)
+	if !ok || string(plaintext) != "hello" {
+		t.Fatalf("a payload sealed for a joined room did not open on a node that owns it")
+	}
+}
+
+// Rooms on one node stay isolated from each other: same channel name, unrelated
+// topics, and a seal from one is not openable by another.
+func TestRoomsOnOneNodeStayIsolated(t *testing.T) {
+	node, err := NewNode("room-a", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	if code := node.JoinRoom("room-b", nil); code != MOSS_OK {
+		t.Fatalf("JoinRoom: %d", code)
+	}
+
+	own := node.roomTopicIn("", "chat")
+	joined := node.roomTopicIn("room-b", "chat")
+	if own == joined {
+		t.Fatalf("both rooms mapped %q to the same topic %q — one conversation would "+
+			"receive another's traffic", "chat", own)
+	}
+
+	sealed, err := node.sealRoomIn("room-b", []byte("for b only"))
+	if err != nil {
+		t.Fatalf("sealRoomIn: %v", err)
+	}
+	if _, ok := node.openRoom("", sealed); ok {
+		t.Fatal("room-a's key opened a payload sealed for room-b")
+	}
+}
+
+// A room that was never joined has no key, so there is nothing to publish
+// under. Falling back to the node's own room would put the payload on a topic
+// the intended peers do not read — a silent misdelivery rather than an error.
+func TestUnjoinedRoomIsRefusedRatherThanSubstituted(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Trackers = nil
+	cfg.LANDiscoveryEnabled = false
+	node, err := NewNode("room-a", nil, cfg)
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	// Started, so the publish reaches the room check rather than stopping at
+	// MOSS_ERR_NOT_STARTED.
+	if code := node.Start(); code != MOSS_OK {
+		t.Fatalf("Start: %d", code)
+	}
+	defer node.Stop()
+	if code := node.SubscribeRoom("room-unknown", "chat"); code != MOSS_ERR_NOT_IN_ROOM {
+		t.Fatalf("SubscribeRoom into an unjoined room returned %d, want MOSS_ERR_NOT_IN_ROOM", code)
+	}
+	if code := node.PublishRoom("room-unknown", "chat", []byte("x")); code != MOSS_ERR_NOT_IN_ROOM {
+		t.Fatalf("PublishRoom into an unjoined room returned %d, want MOSS_ERR_NOT_IN_ROOM", code)
+	}
+	if topic := node.roomTopicIn("room-unknown", "chat"); topic != "" {
+		t.Fatalf("an unjoined room produced topic %q; it must produce none", topic)
+	}
+}
+
+// Delivery picks the key from what the topic was subscribed under, so a message
+// arriving for a joined room is opened with that room's key rather than the
+// node's own.
+func TestDeliveryOpensWithTheSubscribedRoomsKey(t *testing.T) {
+	receiver, err := NewNode("room-a", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	if code := receiver.JoinRoom("room-b", nil); code != MOSS_OK {
+		t.Fatalf("JoinRoom: %d", code)
+	}
+	if code := receiver.SubscribeRoom("room-b", "chat"); code != MOSS_OK {
+		t.Fatalf("SubscribeRoom: %d", code)
+	}
+
+	delivered := make(chan string, 1)
+	receiver.SetMessageCallback(func(channel string, _ [32]byte, data []byte) {
+		delivered <- channel + "|" + string(data)
+	})
+
+	sender, err := NewNode("room-b", nil, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	sealed, err := sender.sealRoom([]byte("payload"))
+	if err != nil {
+		t.Fatalf("sealRoom: %v", err)
+	}
+	receiver.deliverLocal(gossip.Envelope{
+		Type:    gossip.TypePublish,
+		Channel: sender.roomTopic("chat"),
+		Payload: sealed,
+	})
+
+	select {
+	case got := <-delivered:
+		if got != "chat|payload" {
+			t.Fatalf("delivered %q, want the bare channel and the opened payload", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("nothing delivered — the joined room's key was not used to open it")
+	}
+}

--- a/internal/mesh/node_types.go
+++ b/internal/mesh/node_types.go
@@ -24,12 +24,19 @@ type Node struct {
 	networkID string
 	meshID    string
 	psk       []byte
-	// roomKey is the per-room symmetric key (empty for a substrate-only node);
-	// it seals pub/sub payloads and derives the opaque wire topics that keep the
-	// substrate room-blind. subChannels maps those opaque topics back to the
-	// bare channel this node subscribed under, for delivery.
+	// roomKey is the key of the node's OWN room, meshID (empty for a
+	// substrate-only node); it seals pub/sub payloads and derives the opaque
+	// wire topics that keep the substrate room-blind.
+	//
+	// rooms holds the keys of any FURTHER rooms joined at runtime, so one node
+	// can serve several conversations instead of one node per room — see
+	// node_room.go for why that mattered. Guarded by mu.
+	//
+	// subChannels maps an opaque topic back to the room and bare channel this
+	// node subscribed under, which is how delivery knows which key opens it.
 	roomKey     []byte
-	subChannels map[string]string
+	rooms       map[string][]byte
+	subChannels map[string]subscription
 	config      Config
 	infoHash    [20]byte
 	peerID      [20]byte


### PR DESCRIPTION
## Why

A host that gives each conversation its own room has to start a node per conversation. Node identity is per process, so every one of those nodes presents the **same peer id from a different port**. A remote peer keeps one session per identity: it closes the rest on arrival, and `connectPeer` declines to dial the others at all because it already has that peer id connected.

Measured over three days, mosh clients only:

| node | sessions | dead <1s | discarded handshakes/hour |
|---|---|---|---|
| A | 15,494 | 14,799 | 205 |
| B | 9,772 | 9,419 | 131 |
| C | 8,527 | 8,112 | 113 |

95%+ of every session an active client opens dies inside a second, against only 6–8 distinct peers each. One identity appeared on **27 different ports inside a single hour**. Those are full Noise handshakes — asymmetric crypto — thrown away.

## What changed

A node is still born in one room, and every room-less call still means that room, so no existing behaviour moves. It can now join more:

- `Moss_JoinRoom` / `Moss_LeaveRoom`
- `Moss_SubscribeRoom` / `Moss_UnsubscribeRoom` / `Moss_PublishRoom`

**The crypto is untouched** — same derivation, same HMAC topic, same AEAD seal. What changed is which key is selected. That never needs guessing: a wire topic is an HMAC, so delivery reads the room off the subscription that created the topic instead of trying keys.

A room that was never joined is refused with `MOSS_ERR_NOT_IN_ROOM` rather than falling back to the node's own room — the fallback would publish where the intended peers are not listening and surface as lost messages hours later.

## Compatibility

- Existing symbols unchanged; a host that never joins a second room sees nothing different.
- **A joined room is byte-identical to the same room owned outright.** `TestJoinedRoomIsWireIdenticalToOwningIt` pins exactly this: a consolidated client and an already-released one compute the same topic and can talk. Without it this change would silently cut off every shipped version.

## Verification

- 4 new tests: wire-identity, isolation between rooms on one node, unjoined-room refusal, and delivery opening with the subscribed room's key.
- Each verified to **fail** when the key selection is reverted to single-room.
- Full suite green across all 14 packages; `go vet ./...` clean; c-shared build ok.